### PR TITLE
Added missing key 'versions' in generated packages array

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -67,7 +67,7 @@ EOT
             foreach ($repository->getPackages() as $package) {
                 $name = $package->getName();
                 if (isset($targets[$name]) && $targets[$name]->matches(new VersionConstraint('=', $package->getVersion()))) {
-                    $packages[$package->getName()][$package->getVersion()] = $dumper->dump($package);
+                    $packages[$package->getName()]['versions'][$package->getVersion()] = $dumper->dump($package);
                 }
             }
         }


### PR DESCRIPTION
I've added the `versions` key for package versions in the generated `packages.json` to be compliant with the 'composer' repository type.
