### PR TITLE
Fix notice in build command

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -138,6 +138,7 @@ EOT
 
     private function dumpJson(array $packages, OutputInterface $output, $filename)
     {
+        $repo = array();
         $dumper = new ArrayDumper;
         foreach ($packages as $package) {
             $repo['packages'][$package->getPrettyName()][$package->getPrettyVersion()] = $dumper->dump($package);


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Unit tests pass: n/a

With error reporting on E_ALL, building fails due to a notice in BuildCommand - $repo is undefined.
