### PR TITLE
Force order of the packages

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -128,6 +128,7 @@ EOT
             }
         }
 
+        asort($selected, SORT_STRING);
         return $selected;
     }
 


### PR DESCRIPTION
Noticed that the only thing changing (when no actual updates happen) is the order of the packages in `packages.json` etc.. This PR addresses the problem.
