### PR TITLE
[WIP] add commands to create and maintain a local mirror

### DIFF
--- a/src/Composer/Satis/Command/AddRepoCommand.php
+++ b/src/Composer/Satis/Command/AddRepoCommand.php
@@ -1,0 +1,96 @@
+<?php
+namespace Composer\Satis\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Process\Process;
+use Guzzle\Service\Client;
+use Composer\Json\JsonFile;
+
+class AddRepoCommand extends Command
+{
+    protected $guzzle;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->guzzle = new Client('http://packagist.org');
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('add')
+            ->setDescription('Add a package to satis')
+            ->setDefinition(array(
+                new InputArgument('package', InputArgument::REQUIRED, 'The name of a composer package', null),
+                new InputArgument('repos-dir', InputArgument::OPTIONAL, 'Location where to output built files', null),
+                new InputOption('config-file', null, InputOption::VALUE_NONE, 'The config file to update with the new info'),
+            ))
+            ->setHelp(<<<EOT
+The <info>mirror</info> command reads the given composer.lock file and mirrors
+each git repository so they can be used locally.
+<warning>This will only work for repos hosted on github.</warning>
+EOT
+            )
+        ;
+    }
+
+    /**
+     * @param InputInterface  $input  The input instance
+     * @param OutputInterface $output The output instance
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $dir = $input->getArgument('repos-dir');
+        $package = $input->getArgument('package');
+
+        $output->writeln(' - Fetching <info>'.$package.'</info>');
+        $this->getGitRepo($package, $dir);
+        $output->writeln('');
+
+        if($input->getOption('config-file')){
+            $file = new JsonFile($input->getOption('config-file'));
+            $config = $file->read();
+            $url = realpath($dir.'/'.str_replace('/', '-', $package).'.git');
+            $repo = array('type' => 'git', 'url' => 'file:///'.$url);
+            $config['repositories'][] = $repo;
+            $file->write($config);
+        }
+    }
+
+    protected function getGitRepo($package, $outputDir)
+    {
+        $response = $this->guzzle->get('/packages/'.$package.'.json')->send();
+        $response = $response->getBody(true);
+        $package = json_decode($response);
+        $url = $package->package->repository;
+        if(strpos($url, 'github') === false){
+            return;
+        }
+        $package = $package->package->name;
+        $this->mirrorRepo($package, $url, $outputDir);
+
+        $this->packages[$package] = $url;
+    }
+
+    protected function mirrorRepo($name, $url, $outputDir)
+    {
+        $cmd = 'git clone --mirror %s %s';
+        $dir = $outputDir.'/'.str_replace('/', '-', $name).'.git';
+        if(is_dir($dir)){
+            return;
+        }
+        $process = new Process(sprintf($cmd, $url, $dir));
+        $process->setTimeout(3600);
+        $process->run();
+        if (!$process->isSuccessful()) {
+            throw new \Exception($process->getErrorOutput());
+        }
+
+        print $process->getOutput();
+    }
+}

--- a/src/Composer/Satis/Command/MirrorCommand.php
+++ b/src/Composer/Satis/Command/MirrorCommand.php
@@ -1,0 +1,66 @@
+<?php
+namespace Composer\Satis\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Command\Command;
+use Composer\Json\JsonFile;
+use Symfony\Component\Console\Input\ArrayInput;
+
+class MirrorCommand extends Command
+{
+
+    protected function configure()
+    {
+        $this
+            ->setName('mirror')
+            ->setDescription('Mirrors packages from a composer.lock file to make them available locally')
+            ->setDefinition(array(
+                new InputArgument('file', InputArgument::REQUIRED, 'Json file to use'),
+                new InputArgument('output-dir', InputArgument::OPTIONAL, 'Location where to output built files', null),
+                new InputOption('config-file', null, InputOption::VALUE_NONE, 'The config file to update with the new info'),
+            ))
+            ->setHelp(<<<EOT
+The <info>mirror</info> command reads the given composer.lock file and mirrors
+each git repository so they can be used locally.
+<warning>This will only work for repos hosted on github.</warning>
+EOT
+            )
+        ;
+    }
+
+    /**
+     * @param InputInterface  $input  The input instance
+     * @param OutputInterface $output The output instance
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $file = new JsonFile($input->getArgument('file'));
+        $dir = $input->getArgument('output-dir');
+        $cfg = $input->getOption('config-file');
+        if (!$file->exists()) {
+            $output->writeln('<error>File not found: '.$input->getArgument('file').'</error>');
+
+            return 1;
+        }
+        $repositories = $file->read();
+        $packages = array_unique(array_map(function($package){return $package['package'];}, $repositories['packages']));
+        foreach($packages as $package){
+            $command = $this->getApplication()->find('add');
+
+            $arguments = array(
+                'command'   => 'add',
+                'package'   => $package,
+                'repos-dir' => $dir,
+            );
+            if(!is_null($cfg)){
+                $arguments['--config-file'] = $cfg;
+            }
+
+            $input = new ArrayInput($arguments);
+            $returnCode = $command->run($input, $output);
+        }
+    }
+}

--- a/src/Composer/Satis/Command/UpdateReposCommand.php
+++ b/src/Composer/Satis/Command/UpdateReposCommand.php
@@ -1,0 +1,50 @@
+<?php
+namespace Composer\Satis\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Process\Process;
+
+class UpdateReposCommand extends Command
+{
+
+    protected function configure()
+    {
+        $this
+            ->setName('update')
+            ->setDescription('Fetch last updates from each package')
+            ->setDefinition(array(
+                new InputArgument('repos-dir', InputArgument::OPTIONAL, 'Location where to output built files', null),
+            ))
+            ->setHelp(<<<EOT
+The <info>mirror</info> command reads the given composer.lock file and mirrors
+each git repository so they can be used locally.
+<warning>This will only work for repos hosted on github.</warning>
+EOT
+            )
+        ;
+    }
+
+    /**
+     * @param InputInterface  $input  The input instance
+     * @param OutputInterface $output The output instance
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $dir = $input->getArgument('repos-dir');
+        $repos = glob($dir.'/*.git');
+        $cmd = 'cd %s && git fetch';
+        foreach($repos as $repo){
+            $output->writeln(' - Fetching latest changes in <info>'.$repo.'</info>');
+            $process = new Process(sprintf($cmd, $repo));
+            $process->run();
+            if (!$process->isSuccessful()) {
+                throw new \Exception($process->getErrorOutput());
+            }
+            $output->writeln($process->getOutput());
+        }
+    }
+}

--- a/src/Composer/Satis/Console/Application.php
+++ b/src/Composer/Satis/Console/Application.php
@@ -69,5 +69,8 @@ class Application extends BaseApplication
     protected function registerCommands()
     {
         $this->add(new Command\BuildCommand());
+        $this->add(new Command\MirrorCommand());
+        $this->add(new Command\UpdateReposCommand());
+        $this->add(new Command\AddRepoCommand());
     }
 }


### PR DESCRIPTION
I just want to check if there is any interest for this directly inside of satis or if I should create a separate thing to deal with creating local mirrors.

Added 3 commands:
- `mirror` would take a `composer.lock` file as an input and create a `mirror clone` of each of the repositories.
  - The reason for using a composer.lock is that all the dependencies are already resolved and simple to use. I couldn't find how through composer I could give a `composer.json` and get all the dependencies back. It seems a lot of code would need to be duplicated (at first glance).
  - It takes 2 arguments and one option:
    - argument: `file`: the composer.lock file
    - argument: `output-dir`: the directory where this repository will be cloned
    - option: `--config-file`: if specified, then the command will update a satis `config.json` file with the info from the added repositories.
- `add` does the same as `mirror` except it doesn't take a file as argument but the name of a package
- `update` will go through all of the repositories and fetch the latest code.

Limitations:
- Only works with github and git repositories so far.
- Only works if installed on the same machine so far as repository urls are specified with `file:///`
