### PR TITLE
Allow Satis to be used as mirror for package file downloads

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -90,8 +90,8 @@ EOT
             foreach ($packages as $package) {
                 if ($this->isDownloadable($package->getDistType())) {
                     $packagePath = $this->download($package, $outputDir.'/files');
-                    $distUrl     = isset($config['homepage']) ? $config['homepage'] : $outputDir;
-                    $package->setDistUrl($distUrl.'/files/'.$packagePath);
+                    $distUrl     = isset($config['homepage']) ? $config['homepage'] : $outputDir.'/';
+                    $package->setDistUrl($distUrl.'files/'.$packagePath);
                 }
             }
         }


### PR DESCRIPTION
This pull request introduces the possibility to mirror package file downloads locally with Satis. This can be helpful in a company if you use an Open Source package which hosted externally, but don't want to depend on the external hosting. For example, in the past I experienced outages of Github at the moment I wanted to deploy an application - I wasn't able to install the dependencies at this very moment. With this feature, you can use Satis to host your internal packages as well as mirror external packages in order to decouple your development and deployment from availability of external services.

The patch introduces a new config option `download-files` which must be set to to `true` if you want to enable file mirroring. It mirrors distribution types zip, tar, phar and file. In case of a Github hosted package it also mirrors dev-master.
