### PR TITLE
BuildCommand now catches InvalidRepositoryExceptions

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -135,8 +135,8 @@ EOT
 
         // run over all packages and store matching ones
         $output->writeln('<info>Scanning packages</info>');
-            foreach ($composer->getRepositoryManager()->getRepositories() as $repository) {
-                try {
+        foreach ($composer->getRepositoryManager()->getRepositories() as $repository) {
+            try {
                 foreach ($repository->getPackages() as $package) {
                     // skip aliases
                     if ($package instanceof AliasPackage) {


### PR DESCRIPTION
If a repo in satis.json is not a valid composer repository, Composer throws an InvalidRepositoryException. This is annoying for me, and I think maybe for others?

It is possible that we could make it a command switch (--squelch-errors or something) for flexibility?
