### PR TITLE
Bugfix for dists

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -240,7 +240,7 @@ EOT
         $archiveManager->setOverwriteFiles(false);
 
         /* @var \Composer\Package\CompletePackage $package */
-        foreach ($packages as $name => &$package) {
+        foreach ($packages as $name => $package) {
 
             if (true === $skipDev && true === $package->isDev()) {
                 $output->writeln(sprintf("<info>Skipping '%s' (is dev)</info>", $name));


### PR DESCRIPTION
This fixes the following issues:
- set correct distribution type (tar or zip)
  - e.g. when your local satis overrides that of the upstream (GitHub)
  - dist urls were ignored when previously no dist was 'provided' (e.g. with SVN)
- set the correct dist reference

Resolves: #57

Thanks to @njam for reporting!
