### PR TITLE
Readme features invalid composer-arg `--stability=dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Usage
 -----
 
 - Download Composer: `wget http://getcomposer.org/composer.phar`
-- Install satis: `php composer.phar create-project composer/satis --stability=dev`
+- Install satis: `php composer.phar create-project composer/satis`
 - Build a repository: `php bin/satis build <composer.json> <build-dir>`
 
 Read the more detailed instructions in the 


### PR DESCRIPTION
There is no composer argument `--stability=dev` (any more?).

The `create-project` help text says:

>  To setup a developer workable version you should create the project using the source
>  controlled code by appending the '--prefer-source' flag. Also, it is
>  advisable to install all dependencies required for development by appending the
>  '--dev' flag.

But I think this is not needed to install satis?
