### PR TITLE
Add a "minimum-stability" feature

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -284,13 +284,23 @@ EOT
 
             $output->writeln(sprintf("<info>Dumping '%s'.</info>", $name));
 
-            $path = $archiveManager->archive($package, $format, $directory);
-            $archive = basename($path);
-            $distUrl = sprintf('%s/%s/%s', $endpoint, $config['archive']['directory'], $archive);
-            $package->setDistType($format);
-            $package->setDistUrl($distUrl);
-            $package->setDistSha1Checksum(sha1_file($path));
-            $package->setDistReference($package->getPrettyVersion());
+            try{
+                $path = $archiveManager->archive($package, $format, $directory);
+                $archive = basename($path);
+                $distUrl = sprintf('%s/%s/%s', $endpoint, $config['archive']['directory'], $archive);
+                $package->setDistType($format);
+                $package->setDistUrl($distUrl);
+                $package->setDistSha1Checksum(sha1_file($path));
+                $package->setDistReference($package->getPrettyVersion());
+            }
+            catch(\BadMethodCallException $e)
+            {
+                $output->writeln(sprintf("<info>Cannot dump '%s'</info>", $name));
+            }
+            catch(\RuntimeException $e)
+            {
+                $output->writeln(sprintf("<info>Cannot dump '%s'</info>", $name));
+            }
         }
     }
 


### PR DESCRIPTION
Hi,

I've added this feature so it is now possible to fetch packages with a minimum given stability level by adding the following option to the json config file:

...
"minimum-stability": "stable"
...

just like in composer (see http://getcomposer.org/doc/04-schema.md#minimum-stability for possible values).

This level was previously hard-coded as "dev".

PS: please tell me if I did this the wrong way as this is my very first pull request :-)
