### PR TITLE
Use hash_file('sha1', $foo) instead of sha1_file().

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -284,7 +284,7 @@ EOT
             $distUrl = sprintf('%s/%s/%s', $endpoint, $config['archive']['directory'], $archive);
             $package->setDistType($format);
             $package->setDistUrl($distUrl);
-            $package->setDistSha1Checksum(sha1_file($path));
+            $package->setDistSha1Checksum(hash_file('sha1', $path));
             $package->setDistReference($package->getPrettyVersion());
         }
     }


### PR DESCRIPTION
Matches the code in composer/composer which is used to verify the checksum.

Steps to reproduce:
- use composer/satis and enable archiving
- try to install the artifacts with composer 

Error: 

The checksum verification of the file failed ...
