### PR TITLE
symfony/process is not required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
         "php": ">=5.3.2",
         "composer/composer": "1.0.*@dev",
         "twig/twig": "~1.7",
-        "symfony/console": "~2.1@dev",
-        "symfony/process": "~2.1@dev"
+        "symfony/console": "~2.1@dev"
     },
     "autoload": {
         "psr-0": { "Composer\\Satis": "src/" }


### PR DESCRIPTION
I searched around but couldn't see this component used anywhere in the codebase.
