### PR TITLE
add an absolute directory to dump package where you want

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -260,7 +260,11 @@ EOT
      */
     private function dumpDownloads(array $config, array &$packages, OutputInterface $output, $outputDir)
     {
-        $directory = sprintf('%s/%s', $outputDir, $config['archive']['directory']);
+        if (isset($config['archive']['absolute-directory'])) {
+            $directory = sprintf('%s', $config['archive']['absolute-directory']);
+        } else {
+            $directory = sprintf('%s/%s', $outputDir, $config['archive']['directory']);
+        }
 
         $output->writeln(sprintf("<info>Creating local downloads in '%s'</info>", $directory));
 


### PR DESCRIPTION
I found usefull not to dump packages inside the projet. Download is still allowed by adding a simple alias in my virtual host.
