### PR TITLE
Convert to use providers-urls instead of putting every package in one file

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -140,8 +140,7 @@ EOT
             $this->dumpDownloads($config, $packages, $output, $outputDir, $skipErrors);
         }
 
-        $filename = $outputDir.'/packages.json';
-        $this->dumpJson($packages, $output, $filename);
+        $this->dumpJson($config, $packages, $output, $outputDir);
 
         if ($htmlView) {
             $dependencies = array();
@@ -323,15 +322,39 @@ EOT
         }
     }
 
-    private function dumpJson(array $packages, OutputInterface $output, $filename)
+    private function dumpJson($config, array $packages, OutputInterface $output, $outputDir)
     {
         $repo = array('packages' => array());
+        $repo['providers-url'] = $config['homepage'] . '/packages/%package%.json';
+
+        $providerFiles = array();
+
         $dumper = new ArrayDumper;
         foreach ($packages as $package) {
-            $repo['packages'][$package->getPrettyName()][$package->getPrettyVersion()] = $dumper->dump($package);
+            $fileName = $package->getPrettyName();
+
+            $providerFiles[$fileName][$package->getPrettyVersion()] = $dumper->dump($package);
+            $providerFiles[$fileName][$package->getPrettyVersion()]['uid'] = md5($package->getPrettyName() . $package->getPrettyVersion());
         }
+
+        $providers = array();
+        foreach ($providerFiles as $packageName => $contents)
+        {
+            $json = new JsonFile($outputDir . '/packages/' . $packageName . '.json');
+            $d = array('packages' => array($packageName => $contents));
+            $json->write($d);
+
+            $providers[$packageName] = array('sha256' => hash('sha256', file_get_contents($json->getPath())));
+        }
+
+        $providerJSON = new JsonFile($outputDir . '/provider.json');
+        $providerJSON->write(array('providers' => $providers));
+
+        $repo['provider-includes'] = array();
+        $repo['provider-includes']['provider.json'] = array('sha256' => hash('sha256', file_get_contents($providerJSON->getPath())));
+
         $output->writeln('<info>Writing packages.json</info>');
-        $repoJson = new JsonFile($filename);
+        $repoJson = new JsonFile($outputDir . '/packages.json');
         $repoJson->write($repo);
     }
 


### PR DESCRIPTION
Similar to how packagist works, this splits up all the packages into individual files.

This improves performance of the composer client when reading the satis repository, as it will only grab the packages it requires.

I'm not sure the functionality is fully complete, but it works for me.
### Examples:
##### composer.json

``` json
{
    "repositories": [{
        "type": "composer",
        "url": "http://giggsey.com/satis/"
    }],
    "require": {
        "giggsey/libphonenumber-for-php": "*"
    }
}
```
##### satis.json

``` json
{
    "name": "Test Repository",
    "homepage": "http://giggsey.com/satis/",
    "repositories": [{
        "type": "vcs",
        "url": "https://github.com/php-loep/fractal"
    }, {
        "type": "vcs",
        "url": "https://github.com/giggsey/libphonenumber-for-php.git"
    }],
    "require-all": true
}
```
#### Before:
- http://giggsey.com/satis/packages.json

```
$ composer install -vv --profile
[5.2MB/0.05s] Loading composer repositories with package information
[18.4MB/1.31s] Installing dependencies (including require-dev)
[19.5MB/1.48s]   - Installing giggsey/libphonenumber-for-php (5.9.2)
[19.5MB/1.48s] [19.5MB/2.50s]     Downloading: 0%[19.5MB/2.50s]                 [19.6MB/2.73s]     Downloading[19.7MB/2.99s]     Downloading[19.7MB/3.21s]     Downloading[19.8MB/3.36s]     Downloading[19.9MB/3.59s]     Downloading: 25%[20.0[20.0MB/3.81s]     Downloading[20.0MB/4.04s]     Downloading[20.1MB/4.26s]     Downloading[20.2MB/4.49s]     Downloading[20.2MB/4.71s]     Downloading: 50%[20.3[20.3MB/5.01s]     Downloading[20.4MB/5.24s]     Downloading[20.4MB/5.54s]     Downloading[20.5MB/5.76s]     Downloading[20.6MB/5.99s]     Downloading: 75%[20.7[20.7MB/6.18s]     Downloading[20.7MB/6.47s]     Downloading[20.8MB/6.62s]     Downloading[20.9MB/6.92s]     Downloading[20.9MB/7.08s]     Downloading: 100%[20.9MB/7.08s] 
[19.5MB/7.08s]     Extracting archive
[19.8MB/7.30s] 
[19.8MB/7.30s]     REASON: Required by root: giggsey/libphonenumber-for-php
[19.8MB/7.30s] 
[19.0MB/7.30s] Writing lock file
[19.0MB/7.30s] Generating autoload files
Memory usage: 18.99MB (peak: 23.4MB), time: 7.3s

```
#### After:
- http://giggsey.com/satis2/packages.json
- http://giggsey.com/satis2/provider.json
- http://giggsey.com/satis2/packages/giggsey/libphonenumber-for-php.json

```
$ composer install -vv --profile
[5.3MB/0.05s] Loading composer repositories with package information
[5.8MB/0.06s] Installing dependencies (including require-dev) from lock file
[6.5MB/0.06s]   - Installing giggsey/libphonenumber-for-php (5.9.2)
[6.5MB/0.07s] [6.5MB/1.08s]     Downloading: 0%[6.5MB/1.08s]                    [6.6MB/1.24s]     Downloadin[6.7MB/1.39s]     Downloadin[6.7MB/1.54s]     Downloadin[6.8MB/1.65s]     Downloadin[6.9MB/1.76s]     Downloadin[6.9MB/1.88s]     Downloadin[7.0MB/1.99s]     Downloadin[7.1MB/2.18s]     Downloading: 40%[7.1MB/2.4[7.1MB/2.40s]     Downloadin[7.2MB/2.55s]     Downloadin[7.3MB/2.78s]     Downloadin[7.3MB/2.86s]     Downloadin[7.4MB/3.08s]     Downloadin[7.5MB/3.24s]     Downloadin[7.6MB/3.46s]     Downloadin[7.6MB/3.76s]     Downloading: 80%[7.7MB/3.9[7.7MB/3.99s]     Downloadin[7.8MB/4.14s]     Downloadin[7.8MB/4.37s]     Downloadin[7.9MB/4.59s]     Downloading: 100%[7.9MB/4.59s] 
[6.5MB/4.60s]     Extracting archive
[6.7MB/4.81s] 
[6.7MB/4.81s]     REASON: Required by root: giggsey/libphonenumber-for-php
[6.7MB/4.81s] 
[6.2MB/4.81s] Generating autoload files
Memory usage: 6.25MB (peak: 9.33MB), time: 4.81s
```
