### PR TITLE
Archives downloads github token

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -292,6 +292,7 @@ EOT
         $composerConfig = Factory::createConfig();
         $factory = new Factory;
         $io = new ConsoleIO($input, $output, $this->getApplication()->getHelperSet());
+        $io->loadConfiguration($composerConfig);
 
         /* @var \Composer\Downloader\DownloadManager $downloadManager */
         $downloadManager = $factory->createDownloadManager($io, $composerConfig);


### PR DESCRIPTION
This pull request fix a bug with github token.

Currently the token does not add to queries for download archives
