### PR TITLE
Show branch aliased versions in HTML output

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -200,10 +200,6 @@ EOT
                 } else {
                     // process other repos directly
                     foreach ($repo->getPackages() as $package) {
-                        // skip aliases
-                        if ($package instanceof AliasPackage) {
-                            continue;
-                        }
 
                         if ($package->getStability() > BasePackage::$stabilities[$minimumStability]) {
                             continue;


### PR DESCRIPTION
As per https://github.com/composer/satis/issues/100, include aliases branches into HTML output.

(Clearly the removal-by-comment lacks beauty, but can be tidied up if people agree that aliased versions should appear in the HTML output).