### PR TITLE
Moving DistReference before archiving

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -342,13 +342,13 @@ EOT
             $output->writeln(sprintf("<info>Dumping '%s'.</info>", $name));
 
             try {
+                $package->setDistReference($package->getSourceReference());
                 $path = $archiveManager->archive($package, $format, $directory);
                 $archive = basename($path);
                 $distUrl = sprintf('%s/%s/%s', $endpoint, $config['archive']['directory'], $archive);
                 $package->setDistType($format);
                 $package->setDistUrl($distUrl);
                 $package->setDistSha1Checksum(hash_file('sha1', $path));
-                $package->setDistReference($package->getSourceReference());
             } catch(\Exception $exception) {
                 if(!$skipErrors) {
                     throw $exception;


### PR DESCRIPTION
Previously, if I have an artifact repository that has zip files, with name "jay-logger-1.2.zip", and if I use satis on top of it, it would create an archive file based on the logic in composer to be "jay-logger-1.2-jay-logger-1.2.zip.tar".

The reason being, that the distReference information created by Composer has it as the basename of the file. This causes the file name to be appended between <vendor>-<package>-<distReference>.tar format. If However, the distReference is empty, it would look just fine.
