### PR TITLE
Fixed the handling of metapackages

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -322,6 +322,9 @@ EOT
 
         /* @var \Composer\Package\CompletePackage $package */
         foreach ($packages as $name => $package) {
+            if ('metapackage' === $package->getType()) {
+                continue;
+            }
 
             if (true === $skipDev && true === $package->isDev()) {
                 $output->writeln(sprintf("<info>Skipping '%s' (is dev)</info>", $name));


### PR DESCRIPTION
Metapackages don't have content, so they should be skipped when generating archives.

Closes #134
