### PR TITLE
improve speed of search operation

### DIFF
--- a/views/index.html.twig
+++ b/views/index.html.twig
@@ -37,65 +37,65 @@
 
                 {% for name, package in packages %}
                     <div>
-                    <h3 id="{{ package.highest.name }}">{{ package.highest.name }}</h3>
-                    {% if package.highest.description %}
-                        <p>{{ package.highest.description }}</p>
-                    {% endif %}
-                    <table>
-                        {% if package.highest.homepage %}
-                            <tr>
-                                <th>Homepage</th>
-                                <td><a href="{{ package.highest.homepage }}">{{ package.highest.homepage }}</a></td>
-                            </tr>
+                        <h3 id="{{ package.highest.name }}">{{ package.highest.name }}</h3>
+                        {% if package.highest.description %}
+                            <p>{{ package.highest.description }}</p>
                         {% endif %}
-                        {% if package.highest.license %}
+                        <table>
+                            {% if package.highest.homepage %}
+                                <tr>
+                                    <th>Homepage</th>
+                                    <td><a href="{{ package.highest.homepage }}">{{ package.highest.homepage }}</a></td>
+                                </tr>
+                            {% endif %}
+                            {% if package.highest.license %}
+                                <tr>
+                                    <th>License</th>
+                                    <td>{{ package.highest.license|join(', ') }}</td>
+                                </tr>
+                            {% endif %}
+                            {% if package.highest.authors %}
+                                <tr>
+                                    <th>Authors</th>
+                                    <td>
+                                        {% for author in package.highest.authors %}
+                                            {%- if author.homepage -%}
+                                                <a href="{{ author.homepage }}">{{ author.name }}</a>
+                                            {%- else -%}
+                                                {{ author.name }}
+                                            {%- endif -%}
+                                            {%- if not loop.last -%}, {% endif -%}
+                                        {% endfor %}
+                                    </td>
+                                </tr>
+                            {% endif %}
                             <tr>
-                                <th>License</th>
-                                <td>{{ package.highest.license|join(', ') }}</td>
-                            </tr>
-                        {% endif %}
-                        {% if package.highest.authors %}
-                            <tr>
-                                <th>Authors</th>
+                                <th>Releases</th>
                                 <td>
-                                    {% for author in package.highest.authors %}
-                                        {%- if author.homepage -%}
-                                            <a href="{{ author.homepage }}">{{ author.name }}</a>
+                                    {% for version in package.versions %}
+                                        {%- if version.distType -%}
+                                            <a href="{{ version.distUrl }}" title="{{ version.distReference }}">{{ version.prettyVersion }}</a>
                                         {%- else -%}
-                                            {{ author.name }}
+                                            <a href="{{ version.sourceUrl }}" title="{{ version.sourceReference }}">{{ version.prettyVersion }}</a>
                                         {%- endif -%}
                                         {%- if not loop.last -%}, {% endif -%}
                                     {% endfor %}
                                 </td>
                             </tr>
-                        {% endif %}
-                        <tr>
-                            <th>Releases</th>
-                            <td>
-                                {% for version in package.versions %}
-                                    {%- if version.distType -%}
-                                        <a href="{{ version.distUrl }}" title="{{ version.distReference }}">{{ version.prettyVersion }}</a>
-                                    {%- else -%}
-                                        <a href="{{ version.sourceUrl }}" title="{{ version.sourceReference }}">{{ version.prettyVersion }}</a>
-                                    {%- endif -%}
-                                    {%- if not loop.last -%}, {% endif -%}
-                                {% endfor %}
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>Required by</th>
-                            <td>
-                                {% set package_dependencies = attribute(dependencies, name) %}
-                                {% if package_dependencies|length %}
-                                    <ul>
-                                        {% for dependency in package_dependencies %}
-                                            <li><a href="#{{ dependency }}">{{ dependency }}</a></li>
-                                        {% endfor %}
-                                    </ul>
-                                {% endif %}
-                            </td>
-                        </tr>
-                    </table>
+                            <tr>
+                                <th>Required by</th>
+                                <td>
+                                    {% set package_dependencies = attribute(dependencies, name) %}
+                                    {% if package_dependencies|length %}
+                                        <ul>
+                                            {% for dependency in package_dependencies %}
+                                                <li><a href="#{{ dependency }}">{{ dependency }}</a></li>
+                                            {% endfor %}
+                                        </ul>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        </table>
                     </div>
                 {% endfor %}
             </div>


### PR DESCRIPTION
- group/reduce the dom changes to allow browser more easy optimization
### Why:

there are a lot of packages in http://packages.firegento.com/
### What:

I measured the time spend in packages.each(...) via 
`
console.time('search dev');
console.timeEnd('search dev');
`
and repeating a few searches  
(done on a Chromium on Linux)
### Result before the change:

search dev: 1125.312ms 
search dev: 280.572ms
search dev: 256.294ms
search dev: 265.140ms 
### Result after the change:

search dev: 506.986ms 
search dev: 166.762ms 
search dev: 162.661ms
search dev: 146.391ms
### How:

in short: its easier for a browser to hide a single div with multiple child's, then hiding the child's each by each.

Any questions, wishes left?
