### PR TITLE
Single package build when requires are defined

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -251,6 +251,15 @@ EOT
             }
         } else {
             $links = array_values($composer->getPackage()->getRequires());
+
+            // only pick up packages in our filter, if a filter has been set.
+            if (count($packagesFilter) > 0) {
+                 $links = array_filter($links, function(Link $link) use ($packagesFilter) {
+                     return in_array($link->getTarget(), $packagesFilter);
+                });
+            }
+
+            $links = array_values($links);
         }
 
 


### PR DESCRIPTION
Addition for https://github.com/composer/satis/pull/125: Making sure that the single package handling logic works for requires that are defined in the configuration file.
