### PR TITLE
Fixed PEAR packages mirroring

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -396,7 +396,7 @@ EOT
                         $filesystem->ensureDirectoryExists($downloadDir);
                         $downloadManager->download($package, $downloadDir, false);
                         $filesystem->ensureDirectoryExists($directory);
-                        copy($downloadDir . '/' . pathinfo($package->getDistUrl(), PATHINFO_BASENAME), $path);
+                        $filesystem->rename($downloadDir . '/' . pathinfo($package->getDistUrl(), PATHINFO_BASENAME), $path);
                         $filesystem->removeDirectory($downloadDir);
                     }
                     // Set archive format to `file` to tell composer to download it as is


### PR DESCRIPTION
Fixed issue https://github.com/composer/composer/issues/3018 by dumping PEAR packeges in correct format to allow Composer to install PEAR packages correctly.
