### PR TITLE
Display "support" package section

### DIFF
--- a/views/index.html.twig
+++ b/views/index.html.twig
@@ -69,7 +69,7 @@
                                     </td>
                                 </tr>
                             {% endif %}
-							{% if package.highest.support %}
+                            {% if package.highest.support %}
                             <tr>
                                 <th>Support</th>
                                 <td>


### PR DESCRIPTION
Composer schema defines "support" section: https://getcomposer.org/doc/04-schema.md#support

Is there a way to display this block on generated packages page as well as it might be very useful? It would be appreciated. Thank you!
