### PR TITLE
[WIP] Add pre-archive-dump-cmd support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,16 @@
             "homepage": "http://www.naderman.de"
         }
     ],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "git@github.com:andrerom/composer.git"
+        }
+    ],
     "bin": ["bin/satis"],
     "require": {
         "php": ">=5.3.2",
-        "composer/composer": "1.0.*@dev",
+        "composer/composer": "dev-archive_fn_split",
         "twig/twig": "~1.7",
         "symfony/console": "~2.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2366f26d4014bb12ef7a9ac58c28a624",
+    "hash": "f48b22f3055540a5e2931d5767bfa5dc",
     "packages": [
         {
             "name": "composer/composer",
-            "version": "dev-master",
+            "version": "dev-archive_fn_split",
             "source": {
                 "type": "git",
-                "url": "https://github.com/composer/composer.git",
-                "reference": "fc57c97f9f6f1a309dd51a9312218d052b8940c7"
+                "url": "https://github.com/andrerom/composer.git",
+                "reference": "92eb7c86e7d3608bec86ae77ba71564ae7ddb98e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/fc57c97f9f6f1a309dd51a9312218d052b8940c7",
-                "reference": "fc57c97f9f6f1a309dd51a9312218d052b8940c7",
+                "url": "https://api.github.com/repos/andrerom/composer/zipball/92eb7c86e7d3608bec86ae77ba71564ae7ddb98e",
+                "reference": "92eb7c86e7d3608bec86ae77ba71564ae7ddb98e",
                 "shasum": ""
             },
             "require": {
@@ -49,22 +49,24 @@
                     "Composer": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-0": {
+                    "Composer\\Test": "tests/"
+                }
+            },
             "license": [
                 "MIT"
             ],
             "authors": [
                 {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be",
-                    "role": "Developer"
-                },
-                {
                     "name": "Nils Adermann",
                     "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de",
-                    "role": "Developer"
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
                 }
             ],
             "description": "Composer helps you declare, manage and install dependencies of PHP projects, ensuring you have the right stack everywhere.",
@@ -74,7 +76,12 @@
                 "dependency",
                 "package"
             ],
-            "time": "2014-06-05 14:10:53"
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/composer/issues",
+                "source": "https://github.com/andrerom/composer/tree/archive_fn_split"
+            },
+            "time": "2014-06-12 20:45:33"
         },
         {
             "name": "justinrainbow/json-schema",

--- a/src/Composer/Satis/Event/PreArchiveDumpEvent.php
+++ b/src/Composer/Satis/Event/PreArchiveDumpEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of Satis.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *     Nils Adermann <naderman@naderman.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Satis\Event;
+
+use Composer\EventDispatcher;
+
+/**
+ * The pre archive dump event.
+ *
+ * Adds information about path to current extracted package source before it is archived.
+ */
+class PreArchiveDumpEvent extends EventDispatcher\Event implements EventDispatcher\FolderEventInterface
+{
+    /**
+     * @var string
+     */
+    private $packageSourcePath;
+
+    /**
+     * Constructor.
+     *
+     * @param string           $name         The event name
+     * @param string           $packageSourcePath
+     */
+    public function __construct($name, $packageSourcePath)
+    {
+        parent::__construct($name);
+        $this->packageSourcePath = $packageSourcePath;
+    }
+
+    /**
+     * Returns the package package source path as current working directory.
+     *
+     * @return string
+     */
+    public function getCurrentWorkingDirectory()
+    {
+        return $this->packageSourcePath;
+    }
+}


### PR DESCRIPTION
Uses changes done in composer/composer#3053 to be able to execute build scripts before archives are generated.

Name of event could be different, for instance "pre-package-archive".
For use see issue link below.

Resolves composer/satis#153

Possible todo:
- [ ] Reconsider event name
- [ ] Somehow add possibility to have per package commands
