### PR TITLE
Added twig filter to edit the source url

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -453,6 +453,13 @@ EOT
         $templateDir = $template ? pathinfo($template, PATHINFO_DIRNAME) : __DIR__.'/../../../../views';
         $loader = new \Twig_Loader_Filesystem($templateDir);
         $twig = new \Twig_Environment($loader);
+        
+        //add a twig filter to turn urls like git@bitbucket.org:Comapny/repo.git into http://bitbucket.org/Comapny/repo.git
+        $filter = new \Twig_SimpleFilter('git_url', function ($url) {
+            return preg_replace('|git@([^:]+):|si', 'http://$1/', $url);
+        });
+        $twig->addFilter($filter);
+
 
         $mappedPackages = $this->getMappedPackageList($packages);
 

--- a/views/index.html.twig
+++ b/views/index.html.twig
@@ -86,9 +86,9 @@
                                 <td>
                                     {% for version in package.versions %}
                                         {%- if version.distType -%}
-                                            <a href="{{ version.distUrl }}" title="{{ version.distReference }}">{{ version.prettyVersion }}</a>
+                                            <a href="{{ version.distUrl|git_url }}" title="{{ version.distReference }}">{{ version.prettyVersion }}</a>
                                         {%- else -%}
-                                            <a href="{{ version.sourceUrl }}" title="{{ version.sourceReference }}">{{ version.prettyVersion }}</a>
+                                            <a href="{{ version.sourceUrl|git_url }}" title="{{ version.sourceReference }}">{{ version.prettyVersion }}</a>
                                         {%- endif -%}
                                         {%- if not loop.last -%}, {% endif -%}
                                     {% endfor %}


### PR DESCRIPTION
Added a twig filter to turn urls like `git@bitbucket.org:Comapny/repo.git` into `http://bitbucket.org/Comapny/repo.git`

Without this fix, the link to any release would be `http://satis-domain.com/git@bitbucket.org:Comapny/repo.git`. 