### PR TITLE
Require NameMatch for provided packages

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -271,7 +271,7 @@ EOT
             $link = $links[$i];
             $i++;
             $name = $link->getTarget();
-            $matches = $pool->whatProvides($name, $link->getConstraint());
+            $matches = $pool->whatProvides($name, $link->getConstraint(), true);
 
             foreach ($matches as $index => $package) {
                 // skip aliases


### PR DESCRIPTION
This patch fixes #129 issue and #139 issue.
