### PR TITLE
Add commands which help manage configuration file

### DIFF
--- a/src/Composer/Satis/Command/AddCommand.php
+++ b/src/Composer/Satis/Command/AddCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of Satis.
+ *
+ * (c) Sergey Kolodyazhnyy <sergey.kolodyazhnyy@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Satis\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Composer\Command\Command;
+use Composer\Config;
+use Composer\Json\JsonFile;
+
+/**
+ * @author Sergey Kolodyazhnyy <sergey.kolodyazhnyy@gmail.com>
+ */
+class AddCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('add')
+            ->setDescription('Add repository URL to satis JSON file')
+            ->setDefinition(array(
+                new InputArgument('url',  InputArgument::REQUIRED, 'VCS repository URL'),
+                new InputArgument('file', InputArgument::OPTIONAL, 'JSON file to use', './satis.json')
+            ))
+            ->setHelp(<<<EOT
+The <info>add</info> command adds given repository URL to the json file
+(satis.json is used by default). You will need to run <comment>build</comment> command to
+fetch updates from repository.
+EOT
+            )
+        ;
+    }
+
+    /**
+     * @param InputInterface  $input  The input instance
+     * @param OutputInterface $output The output instance
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $configFile = $input->getArgument('file');
+        $repositoryUrl = $input->getArgument('url');
+
+        if (preg_match('{^https?://}i', $configFile)) {
+            $output->writeln('<error>Unable to write to remote file '.$configFile.'</error>');
+            return 2;
+        }
+
+        $file = new JsonFile($configFile);
+        if (!$file->exists()) {
+            $output->writeln('<error>File not found: '.$configFile.'</error>');
+            return 1;
+        }
+
+        $config = $file->read();
+        if (!isset($config['repositories']) || !is_array($config['repositories'])) {
+            $config['repositories'] = array();
+        }
+
+        $config['repositories'][] = array('type' => 'vcs', 'url'  => $repositoryUrl);
+
+        $file->write($config);
+
+        return 0;
+    }
+
+}

--- a/src/Composer/Satis/Command/AddCommand.php
+++ b/src/Composer/Satis/Command/AddCommand.php
@@ -11,6 +11,9 @@
 
 namespace Composer\Satis\Command;
 
+use Composer\Factory;
+use Composer\IO\NullIO;
+use Composer\Repository\VcsRepository;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
@@ -48,6 +51,8 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $formatter = $this->getHelperSet()->get('formatter');
+
         $configFile = $input->getArgument('file');
         $repositoryUrl = $input->getArgument('url');
 
@@ -62,16 +67,57 @@ EOT
             return 1;
         }
 
+        if (!$this->isRepositoryValid($repositoryUrl)) {
+            $output->writeln('<error>Invalid Repository URL: '.$repositoryUrl.'</error>');
+            return 3;
+        }
+
         $config = $file->read();
         if (!isset($config['repositories']) || !is_array($config['repositories'])) {
             $config['repositories'] = array();
+        }
+
+        foreach ($config['repositories'] as $repository) {
+            if(isset($repository['url']) && $repository['url'] == $repositoryUrl) {
+                $output->writeln('<error>Repository already added to the file</error>');
+                return 4;
+            }
         }
 
         $config['repositories'][] = array('type' => 'vcs', 'url'  => $repositoryUrl);
 
         $file->write($config);
 
+
+        $output->writeln(array(
+            '',
+            $formatter->formatBlock('Your configuration file successfully updated! It\'s time to rebuild your repository', 'bg=blue;fg=white', true),
+            ''
+        ));
+
         return 0;
+    }
+
+    /**
+     * Validate repository URL
+     *
+     * @param $repositoryUrl
+     * @return bool
+     */
+    protected function isRepositoryValid($repositoryUrl)
+    {
+        $io = new NullIO();
+        $config = Factory::createConfig();
+        $io->loadConfiguration($config);
+        $repository = new VcsRepository(array('url' => $repositoryUrl), $io, $config);
+
+        if (!($driver = $repository->getDriver())) {
+            return false;
+        }
+
+        $information = $driver->getComposerInformation($driver->getRootIdentifier());
+
+        return !empty($information['name']);
     }
 
 }

--- a/src/Composer/Satis/Command/InitCommand.php
+++ b/src/Composer/Satis/Command/InitCommand.php
@@ -1,0 +1,184 @@
+<?php
+
+/*
+ * This file is part of Satis.
+ *
+ * (c) Sergey Kolodyazhnyy <sergey.kolodyazhnyy@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Composer\Satis\Command;
+
+use Symfony\Component\Console\Helper\DialogHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Composer\Command\Command;
+use Composer\Config;
+use Composer\Json\JsonFile;
+
+/**
+ * @author Sergey Kolodyazhnyy <sergey.kolodyazhnyy@gmail.com>
+ */
+class InitCommand extends Command
+{
+
+    protected function configure()
+    {
+        $this
+            ->setName('init')
+            ->setDescription('Initialize Satis configuration file')
+            ->setDefinition(array(
+                new InputArgument('file', InputArgument::OPTIONAL, 'JSON file to use', './satis.json'),
+                new InputOption('name', null, InputOption::VALUE_REQUIRED, 'Repository name'),
+                new InputOption('homepage', null, InputOption::VALUE_REQUIRED, 'Home page')
+            ))
+            ->setHelp(<<<EOT
+The <info>init</info> generates configuration file (satis.json is used by default).
+You will need to run <comment>build</comment> command to build repository.
+EOT
+            )
+        ;
+    }
+
+    /**
+     * Print welcome message
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $formatter = $this->getHelperSet()->get('formatter');
+
+        $output->writeln(array(
+            '',
+            $formatter->formatBlock('Welcome to the Satis config generator', 'bg=blue;fg=white', true),
+            ''
+        ));
+
+        $output->writeln(array(
+            '',
+            'This command will guide you through creating your Satis config.',
+            '',
+        ));
+    }
+
+
+    /**
+     * Generate configuration file
+     *
+     * @param InputInterface  $input  The input instance
+     * @param OutputInterface $output The output instance
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $formatter = $this->getHelperSet()->get('formatter');
+
+        $configFile = $input->getArgument('file');
+
+        if (preg_match('{^https?://}i', $configFile)) {
+            $output->writeln('<error>Unable to write to remote file '.$configFile.'</error>');
+            return 2;
+        }
+
+        $file = new JsonFile($configFile);
+        if ($file->exists()) {
+            $output->writeln('<error>Configuration file already exists</error>');
+            return 1;
+        }
+
+        $config = array(
+            'name'         => $input->getOption('name'),
+            'homepage'     => $input->getOption('homepage'),
+            'repositories' => array(),
+            'require-all'  => true
+        );
+
+        $file->write($config);
+
+        $output->writeln(array(
+            '',
+            $formatter->formatBlock('Your configuration file successfully created!', 'bg=blue;fg=white', true),
+            ''
+        ));
+
+        $output->writeln(array(
+            '',
+            'You are ready to add your package repositories',
+            'Use <comment>satis add repository-url</comment> to add them.',
+            '',
+        ));
+
+        return 0;
+    }
+
+    /**
+     * Interact with user
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        /** @var DialogHelper $dialog */
+        $dialog = $this->getHelperSet()->get('dialog');
+
+        $name = $input->getOption('name');
+        $name = $dialog->askAndValidate(
+            $output,
+            $this->getQuestion('Repository name', $name),
+            function ($value) use ($name) {
+                if (null === $value) {
+                    $value = $name;
+                }
+
+                if (!$value) {
+                    throw new \InvalidArgumentException("Repository name should not be empty");
+                }
+
+
+                return $value;
+            }
+        );
+        $input->setOption('name', $name);
+
+        $homepage = $input->getOption('homepage');
+        $homepage = $dialog->askAndValidate(
+            $output,
+            $this->getQuestion('Home page', $homepage),
+            function ($value) use ($homepage) {
+                if (null === $value) {
+                    $value = $homepage;
+                }
+
+                if (!preg_match('/https?:\/\/.+/', $value)) {
+                    throw new \InvalidArgumentException(
+                        "Enter a valid URL it will be used for building your repository"
+                    );
+                }
+
+                return $value;
+            }
+        );
+
+        $input->setOption('homepage', $homepage);
+    }
+
+    /**
+     * Build a question
+     *
+     * @param $question
+     * @param $default
+     * @return string
+     */
+    protected function getQuestion($question, $default)
+    {
+        return ($default ? sprintf("%s (%s)", $question, $default) : $question) . ": ";
+    }
+
+}

--- a/src/Composer/Satis/Console/Application.php
+++ b/src/Composer/Satis/Console/Application.php
@@ -68,6 +68,8 @@ class Application extends BaseApplication
      */
     protected function registerCommands()
     {
+        $this->add(new Command\InitCommand());
+        $this->add(new Command\AddCommand());
         $this->add(new Command\BuildCommand());
     }
 }


### PR DESCRIPTION
Hi,

I have added few commands to help get started with satis. 

- `satis init [config-file]` - allows to generate basic satis configuration file
- `satis add <repository-url> [config-file]` - adds repository URL to the configuration file