### PR TITLE
Discovery command for github private repositories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,18 @@
         }
     ],
     "bin": ["bin/satis"],
+    "config": {
+        "bin-dir": "bin"
+    },
     "require": {
         "php": ">=5.3.2",
         "composer/composer": "1.0.*@dev",
         "twig/twig": "~1.7",
-        "symfony/console": "~2.1"
+        "symfony/console": "~2.1",
+        "knplabs/github-api": "1.3.*@dev"
+    },
+    "require-dev": {
+        "phpspec/phpspec": "2.1.*@dev"
     },
     "autoload": {
         "psr-0": { "Composer\\Satis": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "composer/composer": "1.0.*@dev",
         "twig/twig": "~1.7",
         "symfony/console": "~2.1",
-        "knplabs/github-api": "1.3.*@dev"
+        "knplabs/github-api": "~1.3"
     },
     "require-dev": {
         "phpspec/phpspec": "2.1.*@dev"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c232d7edd11dd7f5d4c55852fa2a3cb9",
+    "hash": "b1b6a203f432a4b543e638c5f0dad65f",
     "packages": [
         {
             "name": "composer/composer",
@@ -234,7 +234,7 @@
         },
         {
             "name": "knplabs/github-api",
-            "version": "dev-master",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KnpLabs/php-github-api.git",
@@ -993,7 +993,6 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "composer/composer": 20,
-        "knplabs/github-api": 20,
         "phpspec/phpspec": 20
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2366f26d4014bb12ef7a9ac58c28a624",
+    "hash": "c232d7edd11dd7f5d4c55852fa2a3cb9",
     "packages": [
         {
             "name": "composer/composer",
@@ -75,6 +75,98 @@
             "time": "2014-10-14 17:21:22"
         },
         {
+            "name": "guzzle/guzzle",
+            "version": "v3.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle3.git",
+                "reference": "54991459675c1a2924122afbb0e5609ade581155"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle3/zipball/54991459675c1a2924122afbb0e5609ade581155",
+                "reference": "54991459675c1a2924122afbb0e5609ade581155",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "php": ">=5.3.3",
+                "symfony/event-dispatcher": "~2.1"
+            },
+            "replace": {
+                "guzzle/batch": "self.version",
+                "guzzle/cache": "self.version",
+                "guzzle/common": "self.version",
+                "guzzle/http": "self.version",
+                "guzzle/inflection": "self.version",
+                "guzzle/iterator": "self.version",
+                "guzzle/log": "self.version",
+                "guzzle/parser": "self.version",
+                "guzzle/plugin": "self.version",
+                "guzzle/plugin-async": "self.version",
+                "guzzle/plugin-backoff": "self.version",
+                "guzzle/plugin-cache": "self.version",
+                "guzzle/plugin-cookie": "self.version",
+                "guzzle/plugin-curlauth": "self.version",
+                "guzzle/plugin-error-response": "self.version",
+                "guzzle/plugin-history": "self.version",
+                "guzzle/plugin-log": "self.version",
+                "guzzle/plugin-md5": "self.version",
+                "guzzle/plugin-mock": "self.version",
+                "guzzle/plugin-oauth": "self.version",
+                "guzzle/service": "self.version",
+                "guzzle/stream": "self.version"
+            },
+            "require-dev": {
+                "doctrine/cache": "~1.3",
+                "monolog/monolog": "~1.0",
+                "phpunit/phpunit": "3.7.*",
+                "psr/log": "~1.0",
+                "symfony/class-loader": "~2.1",
+                "zendframework/zend-cache": "2.*,<2.3",
+                "zendframework/zend-log": "2.*,<2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Guzzle": "src/",
+                    "Guzzle\\Tests": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Guzzle Community",
+                    "homepage": "https://github.com/guzzle/guzzle/contributors"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2014-08-11 04:32:36"
+        },
+        {
             "name": "justinrainbow/json-schema",
             "version": "1.3.7",
             "source": {
@@ -139,6 +231,67 @@
                 "schema"
             ],
             "time": "2014-08-25 02:48:14"
+        },
+        {
+            "name": "knplabs/github-api",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/KnpLabs/php-github-api.git",
+                "reference": "fc2bd5531d221f1f9e7d49238a680e50570bf60b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/KnpLabs/php-github-api/zipball/fc2bd5531d221f1f9e7d49238a680e50570bf60b",
+                "reference": "fc2bd5531d221f1f9e7d49238a680e50570bf60b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "guzzle/guzzle": "~3.7",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "knplabs/gaufrette": "Needed for optional Gaufrette cache"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Github\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Thibault Duplessis",
+                    "email": "thibault.duplessis@gmail.com",
+                    "homepage": "http://ornicar.github.com"
+                },
+                {
+                    "name": "KnpLabs Team",
+                    "homepage": "http://knplabs.com"
+                }
+            ],
+            "description": "GitHub API v3 client",
+            "homepage": "https://github.com/KnpLabs/php-github-api",
+            "keywords": [
+                "api",
+                "gh",
+                "gist",
+                "github"
+            ],
+            "time": "2014-09-23 05:58:10"
         },
         {
             "name": "seld/jsonlint",
@@ -240,6 +393,63 @@
             "description": "Symfony Console Component",
             "homepage": "http://symfony.com",
             "time": "2014-09-25 09:53:56"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v2.5.6",
+            "target-dir": "Symfony/Component/EventDispatcher",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/EventDispatcher.git",
+                "reference": "804eb28dbbfba9ffdab21fe2066744906cea2212"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/804eb28dbbfba9ffdab21fe2066744906cea2212",
+                "reference": "804eb28dbbfba9ffdab21fe2066744906cea2212",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.0",
+                "symfony/dependency-injection": "~2.0,<2.6.0",
+                "symfony/stopwatch": "~2.2"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-10-01 15:43:05"
         },
         {
             "name": "symfony/finder",
@@ -393,11 +603,398 @@
             "time": "2014-10-10 14:09:53"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "f976e5de371104877ebc89bd8fecb0019ed9c119"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f976e5de371104877ebc89bd8fecb0019ed9c119",
+                "reference": "f976e5de371104877ebc89bd8fecb0019ed9c119",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3,<8.0-DEV"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "2.0.*@ALPHA"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Instantiator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2014-10-13 12:58:55"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "38743b677965c48a637097b2746a281264ae2347"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/38743b677965c48a637097b2746a281264ae2347",
+                "reference": "38743b677965c48a637097b2746a281264ae2347",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*@stable"
+            },
+            "suggest": {
+                "dflydev/markdown": "1.0.*",
+                "erusev/parsedown": "~0.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "phpDocumentor": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "mike.vanriel@naenius.com"
+                }
+            ],
+            "time": "2014-08-09 10:27:07"
+        },
+        {
+            "name": "phpspec/php-diff",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/php-diff.git",
+                "reference": "30e103d19519fe678ae64a60d77884ef3d71b28a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/php-diff/zipball/30e103d19519fe678ae64a60d77884ef3d71b28a",
+                "reference": "30e103d19519fe678ae64a60d77884ef3d71b28a",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Diff": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Boulton",
+                    "homepage": "http://github.com/chrisboulton",
+                    "role": "Original developer"
+                }
+            ],
+            "description": "A comprehensive library for generating differences between two hashable objects (strings or arrays).",
+            "time": "2013-11-01 13:02:21"
+        },
+        {
+            "name": "phpspec/phpspec",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/phpspec.git",
+                "reference": "e2554bd63e9a1941a89a44278ef34414813195ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/phpspec/zipball/e2554bd63e9a1941a89a44278ef34414813195ca",
+                "reference": "e2554bd63e9a1941a89a44278ef34414813195ca",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "~1.0,>=1.0.1",
+                "php": ">=5.3.3",
+                "phpspec/php-diff": "~1.0.0",
+                "phpspec/prophecy": "~1.1",
+                "sebastian/exporter": "~1.0",
+                "symfony/console": "~2.3",
+                "symfony/event-dispatcher": "~2.1",
+                "symfony/finder": "~2.1",
+                "symfony/process": "~2.1",
+                "symfony/yaml": "~2.1"
+            },
+            "require-dev": {
+                "behat/behat": "~3.0",
+                "bossa/phpspec2-expect": "~1.0",
+                "symfony/filesystem": "~2.1"
+            },
+            "suggest": {
+                "phpspec/nyan-formatters": "~1.0 – Adds Nyan formatters"
+            },
+            "bin": [
+                "bin/phpspec"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "PhpSpec": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "homepage": "http://marcelloduarte.net/"
+                }
+            ],
+            "description": "Specification-oriented BDD framework for PHP 5.3+",
+            "homepage": "http://phpspec.net/",
+            "keywords": [
+                "BDD",
+                "SpecBDD",
+                "TDD",
+                "spec",
+                "specification",
+                "testing",
+                "tests"
+            ],
+            "time": "2014-11-09 10:39:07"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "9ca52329bcdd1500de24427542577ebf3fc2f1c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/9ca52329bcdd1500de24427542577ebf3fc2f1c9",
+                "reference": "9ca52329bcdd1500de24427542577ebf3fc2f1c9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "~1.0,>=1.0.2",
+                "phpdocumentor/reflection-docblock": "~2.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "http://phpspec.org",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2014-11-17 16:23:49"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "c7d59948d6e82818e1bdff7cadb6c34710eb7dc0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/c7d59948d6e82818e1bdff7cadb6c34710eb7dc0",
+                "reference": "c7d59948d6e82818e1bdff7cadb6c34710eb7dc0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2014-09-10 00:51:36"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.5.6",
+            "target-dir": "Symfony/Component/Yaml",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Yaml.git",
+                "reference": "2d9f527449cabfa8543dd7fa3a466d6ae83d6726"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/2d9f527449cabfa8543dd7fa3a466d6ae83d6726",
+                "reference": "2d9f527449cabfa8543dd7fa3a466d6ae83d6726",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Yaml\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-10-01 05:50:18"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "composer/composer": 20
+        "composer/composer": 20,
+        "knplabs/github-api": 20,
+        "phpspec/phpspec": 20
     },
     "prefer-stable": false,
     "platform": {

--- a/spec/Composer/Satis/Command/DiscoverCommandSpec.php
+++ b/spec/Composer/Satis/Command/DiscoverCommandSpec.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace spec\Composer\Satis\Command;
+
+use Composer\Satis\Provider\ProviderFactory;
+use Composer\Satis\Provider\ProviderInterface;
+use Composer\Satis\Provider\Repository;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DiscoverCommandSpec extends ObjectBehavior
+{
+    function let(ProviderFactory $providerFactory, ProviderInterface $provider, InputInterface $input)
+    {
+        $this->setProviderFactory($providerFactory);
+        $providerFactory->create(Argument::any(), Argument::any(), Argument::any())->willReturn($provider);
+
+        $input->getOption('name')->willReturn('my-repo')->shouldBeCalled();
+        $input->getOption('homepage')->willReturn('http://repo')->shouldBeCalled(2);
+        $input->getOption('exclude')->willReturn(array())->shouldBeCalled();
+        $input->getOption('provider')->willReturn('dummy-provider')->shouldBeCalled();
+        $input->bind(Argument::any())->shouldBeCalled();
+        $input->isInteractive()->willReturn(false);
+        $input->validate()->willReturn(false);
+    }
+
+    function it_sets_basic_options(InputInterface $input, OutputInterface $output, ProviderInterface $provider)
+    {
+        $input->getArgument('organisations')->willReturn(array())->shouldBeCalled();
+        $provider->getRepositories(Argument::any())->shouldNotBeCalled();
+        $output->write('{
+    "name": "my-repo",
+    "homepage": "http:\/\/repo",
+    "repositories": [],
+    "require-all": true
+}')->shouldBeCalled();
+        $this->run($input, $output);
+    }
+
+    function it_generates_json_with_repositories(InputInterface $input, OutputInterface $output,
+                                                 ProviderInterface $provider, Repository $repository)
+    {
+        $input->getArgument('organisations')->willReturn(array('dummy'))->shouldBeCalled();
+        $repository->getName()->willReturn('name');
+        $repository->getUrl()->willReturn('http://url');
+        $provider->getRepositories('dummy')
+            ->willReturn(array($repository))
+            ->shouldBeCalled();
+
+        $output->write('{
+    "name": "my-repo",
+    "homepage": "http:\/\/repo",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "http:\/\/url"
+        }
+    ],
+    "require-all": true
+}')->shouldBeCalled();
+
+        $this->run($input, $output);
+    }
+}

--- a/spec/Composer/Satis/Provider/GithubProviderSpec.php
+++ b/spec/Composer/Satis/Provider/GithubProviderSpec.php
@@ -15,8 +15,8 @@ class GithubProviderSpec extends ObjectBehavior
     {
         $this->beConstructedWith($client);
 
-        $client->api('organization')->willReturn($organization);
-        $client->api('repo')->willReturn($repo);
+        $client->organizations()->willReturn($organization);
+        $client->repositories()->willReturn($repo);
         $repo->contents()->willReturn($contents);
         $organization->setPerPage(Argument::any())->willReturn($organization);
     }
@@ -49,7 +49,7 @@ class GithubProviderSpec extends ObjectBehavior
             )
         );
         $organization->repositories('sample-organisation', 'private')->willReturn($data)->shouldBeCalled();
-        $contents->exists('owner_login', 'sample_repo', 'composer.json', 'master')->willReturn(true);
+        $contents->exists('owner_login', 'sample_repo', 'composer.json')->willReturn(true);
 
         $reposities = $this->getRepositories('sample-organisation');
 
@@ -79,10 +79,8 @@ class GithubProviderSpec extends ObjectBehavior
             )
         );
         $organization->repositories('sample-organisation', 'private')->willReturn($data)->shouldBeCalled();
-        $contents->exists('owner_login', 'sample_repo', 'composer.json', 'master')->willReturn(true);
-        $contents->exists('owner_login', 'sample_repo', 'composer.json', 'develop')->shouldNotBeCalled();
-        $contents->exists('owner_login', 'sample_repo2', 'composer.json', 'master')->willReturn(false);
-        $contents->exists('owner_login', 'sample_repo2', 'composer.json', 'develop')->shouldBeCalled()->willReturn(false);
+        $contents->exists('owner_login', 'sample_repo', 'composer.json')->willReturn(true);
+        $contents->exists('owner_login', 'sample_repo2', 'composer.json')->willReturn(false);
 
         $reposities = $this->getRepositories('sample-organisation');
 

--- a/spec/Composer/Satis/Provider/GithubProviderSpec.php
+++ b/spec/Composer/Satis/Provider/GithubProviderSpec.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace spec\Composer\Satis\Provider;
+
+use Github\Api\Organization;
+use Github\Api\Repo;
+use Github\Api\Repository\Contents;
+use Github\Client;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class GithubProviderSpec extends ObjectBehavior
+{
+    function let(Client $client, Organization $organization, Repo $repo, Contents $contents)
+    {
+        $this->beConstructedWith($client);
+
+        $client->api('organization')->willReturn($organization);
+        $client->api('repo')->willReturn($repo);
+        $repo->contents()->willReturn($contents);
+        $organization->setPerPage(Argument::any())->willReturn($organization);
+    }
+
+    function it_authenticate_with_given_token(Client $client, Organization $organization)
+    {
+        $this->beConstructedWith($client, 'token');
+        $client->authenticate('token', null, Client::AUTH_HTTP_TOKEN)->shouldBeCalled();
+        $organization->repositories('dummy', 'private')->willReturn(array());
+
+        $this->getRepositories('dummy');
+    }
+
+    function it_performs_requests_as_an_anonymous_user(Client $client, Organization $organization)
+    {
+        $client->authenticate(Argument::any(), Argument::any(), Argument::any())->shouldNotBeCalled();
+        $organization->repositories('dummy', 'private')->willReturn(array());
+
+        $this->getRepositories('dummy');
+    }
+
+    function it_returns_an_array_of_repositories_from_github(Organization $organization, Contents $contents)
+    {
+        $data = array(
+            array(
+                'owner' => array('login' => 'owner_login'),
+                'name' => 'sample_repo',
+                'full_name' => 'sample-organisation/sample_repo',
+                'git_url' => 'git@github.com/example/repo.git'
+            )
+        );
+        $organization->repositories('sample-organisation', 'private')->willReturn($data)->shouldBeCalled();
+        $contents->exists('owner_login', 'sample_repo', 'composer.json', 'master')->willReturn(true);
+
+        $reposities = $this->getRepositories('sample-organisation');
+
+        $reposities->shouldBeArray();
+        $reposities->shouldHaveCount(1);
+
+        $repo = $reposities[0];
+        $repo->shouldBeAnInstanceOf('Composer\Satis\Provider\Repository');
+        $repo->getName()->shouldBe($data[0]['full_name']);
+        $repo->getUrl()->shouldBe($data[0]['git_url']);
+    }
+
+    function it_filters_non_composer_aware_repositories(Organization $organization, Contents $contents)
+    {
+        $data = array(
+            array(
+                'owner' => array('login' => 'owner_login'),
+                'name' => 'sample_repo',
+                'full_name' => 'sample-organisation/sample_repo',
+                'git_url' => 'git@github.com/sample-organisation/sample_repo.git'
+            ),
+            array(
+                'owner' => array('login' => 'owner_login'),
+                'name' => 'sample_repo2',
+                'full_name' => 'sample-organisation/sample_repo2',
+                'git_url' => 'git@github.com/sample-organisation/sample_repo2.git'
+            )
+        );
+        $organization->repositories('sample-organisation', 'private')->willReturn($data)->shouldBeCalled();
+        $contents->exists('owner_login', 'sample_repo', 'composer.json', 'master')->willReturn(true);
+        $contents->exists('owner_login', 'sample_repo', 'composer.json', 'develop')->shouldNotBeCalled();
+        $contents->exists('owner_login', 'sample_repo2', 'composer.json', 'master')->willReturn(false);
+        $contents->exists('owner_login', 'sample_repo2', 'composer.json', 'develop')->shouldBeCalled()->willReturn(false);
+
+        $reposities = $this->getRepositories('sample-organisation');
+
+        $reposities->shouldBeArray();
+        $reposities->shouldHaveCount(1);
+    }
+}

--- a/spec/Composer/Satis/Provider/ProviderFactorySpec.php
+++ b/spec/Composer/Satis/Provider/ProviderFactorySpec.php
@@ -7,7 +7,6 @@ use Composer\Config;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 class ProviderFactorySpec extends ObjectBehavior
 {
@@ -18,32 +17,32 @@ class ProviderFactorySpec extends ObjectBehavior
         $composer->getConfig()->willReturn($config);
     }
 
-    function it_throws_an_exception_for_unknown_type(InputInterface $input, OutputInterface $output)
+    function it_throws_an_exception_for_unknown_type(InputInterface $input)
     {
         $this->shouldThrow('\Composer\Satis\Provider\UnknownProviderException')
-            ->duringCreate('unknown', $input, $output);
+            ->duringCreate('unknown', $input);
     }
 
-    function it_creates_new_instance_of_the_github_provider(InputInterface $input, OutputInterface $output)
+    function it_creates_new_instance_of_the_github_provider(InputInterface $input)
     {
-        $provider = $this->create('github', $input, $output);
+        $provider = $this->create('github', $input);
         $provider->shouldBeAnInstanceOf('\Composer\Satis\Provider\GithubProvider');
     }
 
-    function it_uses_token_from_input_option(InputInterface $input, OutputInterface $output, Config $config)
+    function it_uses_token_from_input_option(InputInterface $input, Config $config)
     {
         $input->getOption('auth')->willReturn('xxx')->shouldBeCalled();
         $config->get('github-oauth')->shouldNotBeCalled();
 
-        $this->create('github', $input, $output);
+        $this->create('github', $input);
     }
 
-    function it_uses_token_from_composer_configuration(InputInterface $input, OutputInterface $output, Config $config)
+    function it_uses_token_from_composer_configuration(InputInterface $input, Config $config)
     {
         $input->getOption('auth')->willReturn(null);
         $config->has('github-oauth')->willReturn(true);
         $config->get('github-oauth')->willReturn('xxx')->shouldBeCalled();
 
-        $this->create('github', $input, $output);
+        $this->create('github', $input);
     }
 }

--- a/spec/Composer/Satis/Provider/ProviderFactorySpec.php
+++ b/spec/Composer/Satis/Provider/ProviderFactorySpec.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace spec\Composer\Satis\Provider;
+
+use Composer\Composer;
+use Composer\Config;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ProviderFactorySpec extends ObjectBehavior
+{
+    function let(Composer $composer, Config $config)
+    {
+        $this->beConstructedWith($composer);
+
+        $composer->getConfig()->willReturn($config);
+    }
+
+    function it_throws_an_exception_for_unknown_type(InputInterface $input, OutputInterface $output)
+    {
+        $this->shouldThrow('\Composer\Satis\Provider\UnknownProviderException')
+            ->duringCreate('unknown', $input, $output);
+    }
+
+    function it_creates_new_instance_of_the_github_provider(InputInterface $input, OutputInterface $output)
+    {
+        $provider = $this->create('github', $input, $output);
+        $provider->shouldBeAnInstanceOf('\Composer\Satis\Provider\GithubProvider');
+    }
+
+    function it_uses_token_from_input_option(InputInterface $input, OutputInterface $output, Config $config)
+    {
+        $input->getOption('auth')->willReturn('xxx')->shouldBeCalled();
+        $config->get('github-oauth')->shouldNotBeCalled();
+
+        $this->create('github', $input, $output);
+    }
+
+    function it_uses_token_from_composer_configuration(InputInterface $input, OutputInterface $output, Config $config)
+    {
+        $input->getOption('auth')->willReturn(null);
+        $config->has('github-oauth')->willReturn(true);
+        $config->get('github-oauth')->willReturn('xxx')->shouldBeCalled();
+
+        $this->create('github', $input, $output);
+    }
+}

--- a/spec/Composer/Satis/Provider/RepositorySpec.php
+++ b/spec/Composer/Satis/Provider/RepositorySpec.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace spec\Composer\Satis\Provider;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class RepositorySpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith('name', 'url');
+    }
+
+    function it_sets_properties_form_constructor()
+    {
+        $this->getName()->shouldBe('name');
+        $this->getUrl()->shouldBe('url');
+    }
+}

--- a/src/Composer/Satis/Command/DiscoverCommand.php
+++ b/src/Composer/Satis/Command/DiscoverCommand.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Composer\Satis\Command;
+
+use Composer\Satis\Provider\ProviderFactory;
+use Composer\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DiscoverCommand extends Command
+{
+    /**
+     * @var ProviderFactory
+     */
+    protected $providerFactory;
+
+    public function setProviderFactory(ProviderFactory $providerFactory)
+    {
+        $this->providerFactory = $providerFactory;
+    }
+
+    public function getProviderFactory()
+    {
+        if ($this->providerFactory === null) {
+            $this->providerFactory = new ProviderFactory($this->getApplication()->getComposer());
+        }
+
+        return $this->providerFactory;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('discover')
+            ->setDescription('Generates json file which can be used to generate repository from the given provider')
+            ->setDefinition(array(
+                new InputOption('provider', 'p', InputOption::VALUE_OPTIONAL, 'Provider which should be used to fetch list of repositories', 'github'),
+                new InputOption('auth', 'a', InputOption::VALUE_OPTIONAL, 'Authentication data in provider specific format'),
+                new InputOption('name', null, InputOption::VALUE_OPTIONAL, 'Name of the repository', 'My repository'),
+                new InputOption('homepage', null, InputOption::VALUE_OPTIONAL, 'Homepage of the repository'),
+                new InputOption('exclude', 'e', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Exclude named repositories'),
+                new InputArgument('organisations', InputArgument::IS_ARRAY, 'List of the organisations / namespaces which should be scanned for composer repositories.', null),
+            ))
+            ->setHelp(<<<EOT
+EOT
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $provider = $this->getProviderFactory()->create($input->getOption('provider'), $input, $output);
+
+        $data = new \stdClass();
+        $data->name = $input->getOption('name');
+
+        if ($input->getOption('homepage') !== null) {
+            $data->homepage =  $input->getOption('homepage');
+        }
+
+        $excludes = $input->getOption('exclude');
+
+        $data->repositories = array();
+
+        foreach ($input->getArgument('organisations') as $organisation) {
+            foreach ($provider->getRepositories($organisation) as $repository) {
+                if (in_array($repository->getName(), $excludes)) {
+                    continue;
+                }
+
+                $data->repositories[] = array('type' => 'vcs', 'url' => $repository->getUrl());
+            }
+        }
+
+        $data->{'require-all'} = true;
+
+        $output->write(json_encode($data, JSON_PRETTY_PRINT));
+    }
+} 

--- a/src/Composer/Satis/Command/DiscoverCommand.php
+++ b/src/Composer/Satis/Command/DiscoverCommand.php
@@ -43,9 +43,6 @@ class DiscoverCommand extends Command
                 new InputOption('exclude', 'e', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Exclude named repositories'),
                 new InputArgument('organisations', InputArgument::IS_ARRAY, 'List of the organisations / namespaces which should be scanned for composer repositories.', null),
             ))
-            ->setHelp(<<<EOT
-EOT
-            )
         ;
     }
 

--- a/src/Composer/Satis/Command/DiscoverCommand.php
+++ b/src/Composer/Satis/Command/DiscoverCommand.php
@@ -42,12 +42,33 @@ class DiscoverCommand extends Command
             ->setName('discover')
             ->setDescription('Generates json file which can be used to generate repository from the given provider')
             ->setDefinition(array(
-                new InputOption('provider', 'p', InputOption::VALUE_OPTIONAL, 'Provider which should be used to fetch list of repositories', 'github'),
-                new InputOption('auth', 'a', InputOption::VALUE_OPTIONAL, 'Authentication data in provider specific format'),
+                new InputOption(
+                    'provider',
+                    'p',
+                    InputOption::VALUE_OPTIONAL,
+                    'Provider which should be used to fetch list of repositories',
+                    'github'
+                ),
+                new InputOption(
+                    'auth',
+                    'a',
+                    InputOption::VALUE_OPTIONAL,
+                    'Authentication data in provider specific format'
+                ),
                 new InputOption('name', null, InputOption::VALUE_OPTIONAL, 'Name of the repository', 'My repository'),
                 new InputOption('homepage', null, InputOption::VALUE_OPTIONAL, 'Homepage of the repository'),
-                new InputOption('exclude', 'e', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Exclude named repositories'),
-                new InputArgument('organisations', InputArgument::IS_ARRAY, 'List of the organisations / namespaces which should be scanned for composer repositories.', null),
+                new InputOption(
+                    'exclude',
+                    'e',
+                    InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                    'Exclude named repositories'
+                ),
+                new InputArgument(
+                    'organisations',
+                    InputArgument::IS_ARRAY,
+                    'List of the organisations / namespaces which should be scanned for composer repositories.',
+                    null
+                ),
             ))
         ;
     }
@@ -81,4 +102,4 @@ class DiscoverCommand extends Command
 
         $output->write(json_encode($data, JSON_PRETTY_PRINT));
     }
-} 
+}

--- a/src/Composer/Satis/Command/DiscoverCommand.php
+++ b/src/Composer/Satis/Command/DiscoverCommand.php
@@ -16,11 +16,17 @@ class DiscoverCommand extends Command
      */
     protected $providerFactory;
 
+    /**
+     * @param ProviderFactory $providerFactory
+     */
     public function setProviderFactory(ProviderFactory $providerFactory)
     {
         $this->providerFactory = $providerFactory;
     }
 
+    /**
+     * @return ProviderFactory
+     */
     public function getProviderFactory()
     {
         if ($this->providerFactory === null) {

--- a/src/Composer/Satis/Command/DiscoverCommand.php
+++ b/src/Composer/Satis/Command/DiscoverCommand.php
@@ -63,6 +63,12 @@ class DiscoverCommand extends Command
                     InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                     'Exclude named repositories'
                 ),
+                new InputOption(
+                    'extra',
+                    null,
+                    InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+                    'Extra repository URL which should be scanned'
+                ),
                 new InputArgument(
                     'organisations',
                     InputArgument::IS_ARRAY,
@@ -96,6 +102,10 @@ class DiscoverCommand extends Command
 
                 $data->repositories[] = array('type' => 'vcs', 'url' => $repository->getUrl());
             }
+        }
+
+        foreach ($input->getOption('extra') as $extra) {
+            $data->repositories[] = array('type' => 'vcs', 'url' => $extra);
         }
 
         $data->{'require-all'} = true;

--- a/src/Composer/Satis/Command/DiscoverCommand.php
+++ b/src/Composer/Satis/Command/DiscoverCommand.php
@@ -48,7 +48,7 @@ class DiscoverCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $provider = $this->getProviderFactory()->create($input->getOption('provider'), $input, $output);
+        $provider = $this->getProviderFactory()->create($input->getOption('provider'), $input);
 
         $data = new \stdClass();
         $data->name = $input->getOption('name');

--- a/src/Composer/Satis/Console/Application.php
+++ b/src/Composer/Satis/Console/Application.php
@@ -69,5 +69,6 @@ class Application extends BaseApplication
     protected function registerCommands()
     {
         $this->add(new Command\BuildCommand());
+        $this->add(new Command\DiscoverCommand());
     }
 }

--- a/src/Composer/Satis/Provider/GithubProvider.php
+++ b/src/Composer/Satis/Provider/GithubProvider.php
@@ -32,8 +32,9 @@ class GithubProvider implements ProviderInterface
     public function getRepositories($organisation)
     {
         $repositories = array();
+        $organisations = $this->client->organizations()->setPerPage(100);
 
-        foreach ($this->client->organizations()->setPerPage(100)->repositories($organisation, 'private') as $repository) {
+        foreach ($organisations->repositories($organisation, 'private') as $repository) {
             if (!$this->isComposerAware($repository)) {
                 continue;
             }

--- a/src/Composer/Satis/Provider/GithubProvider.php
+++ b/src/Composer/Satis/Provider/GithubProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Composer\Satis\Provider;
+
+use Github\Client;
+
+class GithubProvider implements ProviderInterface
+{
+    /**
+     * @var Client
+     */
+    private $client;
+
+    /**
+     * @param Client $client
+     * @param null   $token
+     */
+    public function __construct(Client $client, $token = null)
+    {
+        $this->client = $client;
+
+        if ($token !== null) {
+            $this->client->authenticate($token, null, Client::AUTH_HTTP_TOKEN);
+        }
+    }
+
+    /**
+     * @param string $organisation
+     *
+     * @return Repository[]
+     */
+    public function getRepositories($organisation)
+    {
+        $repositories = array();
+
+        foreach ($this->client->api('organization')->setPerPage(100)->repositories($organisation, 'private') as $repository) {
+            if (!$this->isComposerAware($repository)) {
+                continue;
+            }
+
+            $repositories[] = new Repository($repository['full_name'], $repository['git_url']);
+        }
+
+        return $repositories;
+    }
+
+    /**
+     * @param array $repository
+     *
+     * @return array
+     */
+    protected function isComposerAware(array $repository)
+    {
+        return $this->hasComposerFile($repository['owner']['login'], $repository['name'], 'master')
+            || $this->hasComposerFile($repository['owner']['login'], $repository['name'], 'develop');
+    }
+
+    private function hasComposerFile($owner, $repository, $branch)
+    {
+        return $this->client->api('repo')->contents()->exists(
+            $owner,
+            $repository,
+            'composer.json',
+            $branch
+        );
+    }
+}

--- a/src/Composer/Satis/Provider/GithubProvider.php
+++ b/src/Composer/Satis/Provider/GithubProvider.php
@@ -33,7 +33,7 @@ class GithubProvider implements ProviderInterface
     {
         $repositories = array();
 
-        foreach ($this->client->api('organization')->setPerPage(100)->repositories($organisation, 'private') as $repository) {
+        foreach ($this->client->organizations()->setPerPage(100)->repositories($organisation, 'private') as $repository) {
             if (!$this->isComposerAware($repository)) {
                 continue;
             }
@@ -49,19 +49,12 @@ class GithubProvider implements ProviderInterface
      *
      * @return array
      */
-    protected function isComposerAware(array $repository)
+    private function isComposerAware(array $repository)
     {
-        return $this->hasComposerFile($repository['owner']['login'], $repository['name'], 'master')
-            || $this->hasComposerFile($repository['owner']['login'], $repository['name'], 'develop');
-    }
-
-    private function hasComposerFile($owner, $repository, $branch)
-    {
-        return $this->client->api('repo')->contents()->exists(
-            $owner,
-            $repository,
-            'composer.json',
-            $branch
+        return $this->client->repositories()->contents()->exists(
+            $repository['owner']['login'],
+            $repository['name'],
+            'composer.json'
         );
     }
 }

--- a/src/Composer/Satis/Provider/GithubProvider.php
+++ b/src/Composer/Satis/Provider/GithubProvider.php
@@ -47,7 +47,7 @@ class GithubProvider implements ProviderInterface
     /**
      * @param array $repository
      *
-     * @return array
+     * @return boolean
      */
     private function isComposerAware(array $repository)
     {

--- a/src/Composer/Satis/Provider/ProviderFactory.php
+++ b/src/Composer/Satis/Provider/ProviderFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Composer\Satis\Provider;
+
+use Composer\Composer;
+use Github\Client;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ProviderFactory
+{
+    /**
+     * @var Composer
+     */
+    protected $composer;
+
+    /**
+     * @param Composer $composer
+     */
+    public function __construct(Composer $composer)
+    {
+        $this->composer = $composer;
+    }
+
+    /**
+     *
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @throws UnknownProviderException
+     * @return ProviderInterface
+     */
+    public function create($name, InputInterface $input, OutputInterface $output)
+    {
+        switch ($name) {
+            case 'github':
+                $client = new Client();
+
+                $token = null;
+                if ($input->getOption('auth') !== null) {
+                    $token = $input->getOption('auth');
+                } elseif ($this->composer->getConfig()->has('github-oauth')) {
+                    $auth = $this->composer->getConfig()->get('github-oauth');
+                    if (isset($auth['github.com'])) {
+                        $token = $auth['github.com'];
+                    }
+                }
+
+                return new GithubProvider($client, $token);
+                break;
+            default:
+                throw new UnknownProviderException(sprintf('Failed to load provider named: %s', $name));
+        }
+    }
+} 

--- a/src/Composer/Satis/Provider/ProviderFactory.php
+++ b/src/Composer/Satis/Provider/ProviderFactory.php
@@ -23,7 +23,8 @@ class ProviderFactory
 
     /**
      *
-     * @param InputInterface  $input
+     * @param string         $name
+     * @param InputInterface $input
      *
      * @throws UnknownProviderException
      * @return ProviderInterface

--- a/src/Composer/Satis/Provider/ProviderFactory.php
+++ b/src/Composer/Satis/Provider/ProviderFactory.php
@@ -51,4 +51,4 @@ class ProviderFactory
                 throw new UnknownProviderException(sprintf('Failed to load provider named: %s', $name));
         }
     }
-} 
+}

--- a/src/Composer/Satis/Provider/ProviderFactory.php
+++ b/src/Composer/Satis/Provider/ProviderFactory.php
@@ -5,7 +5,6 @@ namespace Composer\Satis\Provider;
 use Composer\Composer;
 use Github\Client;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 class ProviderFactory
 {
@@ -25,12 +24,11 @@ class ProviderFactory
     /**
      *
      * @param InputInterface  $input
-     * @param OutputInterface $output
      *
      * @throws UnknownProviderException
      * @return ProviderInterface
      */
-    public function create($name, InputInterface $input, OutputInterface $output)
+    public function create($name, InputInterface $input)
     {
         switch ($name) {
             case 'github':

--- a/src/Composer/Satis/Provider/ProviderFactory.php
+++ b/src/Composer/Satis/Provider/ProviderFactory.php
@@ -46,7 +46,6 @@ class ProviderFactory
                 }
 
                 return new GithubProvider($client, $token);
-                break;
             default:
                 throw new UnknownProviderException(sprintf('Failed to load provider named: %s', $name));
         }

--- a/src/Composer/Satis/Provider/ProviderInterface.php
+++ b/src/Composer/Satis/Provider/ProviderInterface.php
@@ -10,4 +10,4 @@ interface ProviderInterface
      * @return Repository[]
      */
     public function getRepositories($organisation);
-} 
+}

--- a/src/Composer/Satis/Provider/ProviderInterface.php
+++ b/src/Composer/Satis/Provider/ProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Composer\Satis\Provider;
+
+interface ProviderInterface
+{
+    /**
+     * @param string $organisation
+     *
+     * @return Repository[]
+     */
+    public function getRepositories($organisation);
+} 

--- a/src/Composer/Satis/Provider/Repository.php
+++ b/src/Composer/Satis/Provider/Repository.php
@@ -55,4 +55,4 @@ class Repository
     {
         $this->url = $url;
     }
-} 
+}

--- a/src/Composer/Satis/Provider/Repository.php
+++ b/src/Composer/Satis/Provider/Repository.php
@@ -7,12 +7,12 @@ class Repository
     /**
      * @var string
      */
-    protected $name;
+    private $name;
 
     /**
      * @var string
      */
-    protected $url;
+    private $url;
 
     /**
      * @param string $name
@@ -25,7 +25,7 @@ class Repository
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getName()
     {
@@ -33,7 +33,7 @@ class Repository
     }
 
     /**
-     * @param mixed $name
+     * @param string $name
      */
     public function setName($name)
     {
@@ -41,7 +41,7 @@ class Repository
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getUrl()
     {
@@ -49,7 +49,7 @@ class Repository
     }
 
     /**
-     * @param mixed $url
+     * @param string $url
      */
     public function setUrl($url)
     {

--- a/src/Composer/Satis/Provider/Repository.php
+++ b/src/Composer/Satis/Provider/Repository.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Composer\Satis\Provider;
+
+class Repository
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var string
+     */
+    protected $url;
+
+    /**
+     * @param string $name
+     * @param string $url
+     */
+    public function __construct($name, $url)
+    {
+        $this->name = $name;
+        $this->url = $url;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param mixed $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param mixed $url
+     */
+    public function setUrl($url)
+    {
+        $this->url = $url;
+    }
+} 

--- a/src/Composer/Satis/Provider/UnknownProviderException.php
+++ b/src/Composer/Satis/Provider/UnknownProviderException.php
@@ -6,4 +6,4 @@ use Exception;
 
 class UnknownProviderException extends Exception
 {
-} 
+}

--- a/src/Composer/Satis/Provider/UnknownProviderException.php
+++ b/src/Composer/Satis/Provider/UnknownProviderException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Composer\Satis\Provider;
+
+use Exception;
+
+class UnknownProviderException extends Exception
+{
+
+} 

--- a/src/Composer/Satis/Provider/UnknownProviderException.php
+++ b/src/Composer/Satis/Provider/UnknownProviderException.php
@@ -6,5 +6,4 @@ use Exception;
 
 class UnknownProviderException extends Exception
 {
-
 } 


### PR DESCRIPTION
Added discovery command which can be used for satis.json file generation through different API's (currently there is only Github implementation).

Implementation covered by phpspec tests. 

Sample usage:

```
/bin/satis discover some-organisation
```

More advanced usage:

```
/bin/satis discover --name='My repo name' --homepage="http://example.com" -e some-organisation/some-repo some-organisation other-organisation > ./satis.json
```

Discovery command will use composer configuration for authentication but you may also provide github token via command line option. 