### PR TITLE
Return a non-zero exit code in bootstrap.php.

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -18,9 +18,10 @@ function includeIfExists($file)
 }
 
 if ((!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php')) && (!$loader = includeIfExists(__DIR__.'/../../../autoload.php'))) {
-    die('You must set up the project dependencies, run the following commands:'.PHP_EOL.
-        'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
-        'php composer.phar install'.PHP_EOL);
+    print('You must set up the project dependencies, run the following commands:'.PHP_EOL.
+          'curl -s http://getcomposer.org/installer | php'.PHP_EOL.
+          'php composer.phar install'.PHP_EOL);
+    die(1);
 }
 
 return $loader;


### PR DESCRIPTION
I've been trying to provision a satis repository automatically today. It would be really helpful if `src/bootstrap.php` returned a non-zero exit code so it can be identified as a failure.

Thanks!