### PR TITLE
Update composer dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "0662036f5ebc0bd33b4300fa68c3263c5e4ef584"
+                "reference": "f1a2f5b1d038e117b14d802f766be69ebcdd7bb5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/0662036f5ebc0bd33b4300fa68c3263c5e4ef584",
-                "reference": "0662036f5ebc0bd33b4300fa68c3263c5e4ef584",
+                "url": "https://api.github.com/repos/composer/composer/zipball/f1a2f5b1d038e117b14d802f766be69ebcdd7bb5",
+                "reference": "f1a2f5b1d038e117b14d802f766be69ebcdd7bb5",
                 "shasum": ""
             },
             "require": {
@@ -72,7 +72,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2015-01-11 23:38:42"
+            "time": "2015-02-02 15:36:15"
         },
         {
             "name": "justinrainbow/json-schema",


### PR DESCRIPTION
Satis is still suffering from this issue: composer/composer#3542 - it repeatedly asks for GitHub credentials when running 'satis build'
This PR updates the composer dependency to include the fix from composer/composer#3651