### PR TITLE
Add abandon notices to default twig template

### DIFF
--- a/views/index.html.twig
+++ b/views/index.html.twig
@@ -47,6 +47,9 @@
                         {% if package.highest.description %}
                             <p>{{ package.highest.description }}</p>
                         {% endif %}
+                        {% if package.highest.abandoned %}
+                            <p><em class="abandoned">Abandoned software! {% if package.highest.replacementPackage %}Replace with {{ package.highest.replacementPackage }}.{% else %}Avoid using it, no replacement mentioned.{% endif %}</em></p>
+                        {% endif %}
                         <table>
                             {% if package.highest.homepage %}
                                 <tr>
@@ -91,7 +94,9 @@
                                 <th>Releases</th>
                                 <td>
                                     {% for version in package.versions %}
-                                        {%- if version.distType -%}
+                                        {%- if version.abandoned -%}
+                                            <span class="abandoned" title="abandoned version">{{ version.prettyVersion }}</span>
+                                        {%- elseif version.distType -%}
                                             <a href="{{ version.distUrl }}" title="{{ version.distReference }}">{{ version.prettyVersion }}</a>
                                         {%- else -%}
                                             <a href="{{ version.sourceUrl }}" title="{{ version.sourceReference }}">{{ version.prettyVersion }}</a>

--- a/views/index.html.twig
+++ b/views/index.html.twig
@@ -45,10 +45,11 @@
                     <div>
                         <h3 id="{{ package.highest.name }}">{{ package.highest.name }}</h3>
                         {% if package.highest.description %}
-                            <p>{{ package.highest.description }}</p>
-                        {% endif %}
-                        {% if package.highest.abandoned %}
-                            <p><em class="abandoned">Abandoned software! {% if package.highest.replacementPackage %}Replace with {{ package.highest.replacementPackage }}.{% else %}Avoid using it, no replacement mentioned.{% endif %}</em></p>
+                            <p>{{ package.highest.description }}
+                            {% if package.highest.abandoned %}
+                                <br/><em class="abandoned">Abandoned software! {% if package.highest.replacementPackage %}Replace with {{ package.highest.replacementPackage }}.{% else %}Avoid using it, no replacement mentioned.{% endif %}</em>
+                            {% endif %}
+                            </p>
                         {% endif %}
                         <table>
                             {% if package.highest.homepage %}


### PR DESCRIPTION
With the ability to tag projects as abandoned in Composer, this information should be shown in Satis as well. I tried a simple approach, both enabling this info for the highest package version in a prominent place, as well as for every version in case of the most recent version(s) not being abandoned. There is the ability to style these infos via a new CSS class "abandoned".