### PR TITLE
improve search performance

### DIFF
--- a/views/index.html.twig
+++ b/views/index.html.twig
@@ -41,6 +41,7 @@
                 Filter by package name:
                 <input type="text" id="search" autocomplete="off" autofocus />
 
+                <div id="package-list">
                 {% for name, package in packages %}
                     <div>
                         <h3 id="{{ package.highest.name }}">{{ package.highest.name }}</h3>
@@ -116,6 +117,7 @@
                         </table>
                     </div>
                 {% endfor %}
+                </div>
             </div>
         </div>
         <div id="ft">
@@ -134,10 +136,12 @@
             var ms = 350; // milliseconds
             var needle = $(this).val().toLowerCase(), show;
             timer = setTimeout(function() {
+                $('#package-list').hide();
                 packages.each(function(){
                     show = $(this).text().toLowerCase().indexOf(needle) != -1;
                     $(this).parent().toggle(show);
                 });
+                $('#package-list').show();
             }, ms);
         }).focus();
         $('input#search').change(function(){


### PR DESCRIPTION
each toggle() of a package triggers a render of the browser content,
to reduce the number of renders, we hide the element containing all
packages during the filtering.


with the big number of packages we have at http://packages.firegento.com/ a search can need  >30s.
JS profiling showed, the JS is only busy ~2-3s and idles during the rest.

with this patch the rendering time for a search was reduced to just a few seconds.