### PR TITLE
Randomise package download order

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -327,7 +327,7 @@ EOT
 
     /**
      * @param array           $config   Directory where to create the downloads in, prefix-url, etc..
-     * @param array           $packages Reference to packages so we can rewrite the JSON.
+     * @param array           $packages
      * @param InputInterface  $input
      * @param OutputInterface $output
      * @param string          $outputDir
@@ -335,7 +335,7 @@ EOT
      *
      * @return void
      */
-    private function dumpDownloads(array $config, array &$packages, InputInterface  $input, OutputInterface $output, $outputDir, $skipErrors)
+    private function dumpDownloads(array $config, array $packages, InputInterface  $input, OutputInterface $output, $outputDir, $skipErrors)
     {
         if (isset($config['archive']['absolute-directory'])) {
             $directory = $config['archive']['absolute-directory'];

--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -364,11 +364,14 @@ EOT
 
         $archiveManager->setOverwriteFiles(false);
 
+        shuffle($packages);
         /* @var \Composer\Package\CompletePackage $package */
-        foreach ($packages as $name => $package) {
+        foreach ($packages as $package) {
             if ('metapackage' === $package->getType()) {
                 continue;
             }
+
+            $name = $package->getName();
 
             if (true === $skipDev && true === $package->isDev()) {
                 $output->writeln(sprintf("<info>Skipping '%s' (is dev)</info>", $name));


### PR DESCRIPTION
Initial builds can take a very long time in Satis when there are many dependencies. This PR takes a pragmatic approach to speeding this up by making it practical to run many `satis build` commands simultaneously using the same configuration: The download order of the packages is simply randomised to reduce the likelihood of multiple builds attempting to download the same packages at the same time. We have used this approach internally a number of times and it's helped a lot.

This PR includes the changes made in #224.