### PR TITLE
Use the normalized name as key in the metadata file

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -431,7 +431,7 @@ EOT
         $repo = array('packages' => array());
         $dumper = new ArrayDumper;
         foreach ($packages as $package) {
-            $repo['packages'][$package->getPrettyName()][$package->getPrettyVersion()] = $dumper->dump($package);
+            $repo['packages'][$package->getName()][$package->getPrettyVersion()] = $dumper->dump($package);
         }
         $repoJson = new JsonFile($filename);
         $repoJson->write($repo);


### PR DESCRIPTION
Packagist is using the normalized name as key in the package list. Satis should be consistent. Thus, using the pretty name as key makes the key access unusable as the code would have to try any case variation.