### PR TITLE
Fixed typo in build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Usage
 
 - Download [Composer](https://getcomposer.org/download/): `curl -sS https://getcomposer.org/installer | php`
 - Install satis: `php composer.phar create-project composer/satis --stability=dev --keep-vcs`
-- Build a repository: `php bin/satis build <composer.json> <build-dir>`
+- Build a repository: `php bin/satis build <configuration file> <build-dir>`
 
 Read the more detailed instructions in the 
 [documentation](http://getcomposer.org/doc/articles/handling-private-packages-with-satis.md).


### PR DESCRIPTION
The build command specifies using composer.json as the build file. This should be something like config.json.

See the documentation on: https://getcomposer.org/doc/articles/handling-private-packages-with-satis.md
- This is the correct info: `php bin/satis build <configuration file> <build dir>`

The build command step on README.md and handling-private-packages-with-satis.md will be the same with this change.