### PR TITLE
Create Factory instance in Application instead of BuildCommand

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -34,7 +34,6 @@ use Composer\Repository\ComposerRepository;
 use Composer\Repository\PlatformRepository;
 use Composer\Json\JsonFile;
 use Composer\Satis\Satis;
-use Composer\Factory;
 use Composer\Util\Filesystem;
 use Composer\Util\RemoteFilesystem;
 use Composer\IO\ConsoleIO;
@@ -351,8 +350,9 @@ EOT
         $whitelist = isset($config['archive']['whitelist']) ? (array) $config['archive']['whitelist'] : array();
         $blacklist = isset($config['archive']['blacklist']) ? (array) $config['archive']['blacklist'] : array();
 
-        $composerConfig = Factory::createConfig();
-        $factory = new Factory;
+		$factory = $this->getApplication()->getComposerFactory();
+        $composerConfig = $factory->createConfig();
+
         $io = new ConsoleIO($input, $output, $this->getApplication()->getHelperSet());
         $io->loadConfiguration($composerConfig);
 

--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -350,7 +350,7 @@ EOT
         $whitelist = isset($config['archive']['whitelist']) ? (array) $config['archive']['whitelist'] : array();
         $blacklist = isset($config['archive']['blacklist']) ? (array) $config['archive']['blacklist'] : array();
 
-		$factory = $this->getApplication()->getComposerFactory();
+        $factory = $this->getApplication()->getComposerFactory();
         $composerConfig = $factory->createConfig();
 
         $io = new ConsoleIO($input, $output, $this->getApplication()->getHelperSet());

--- a/src/Composer/Satis/Console/Application.php
+++ b/src/Composer/Satis/Console/Application.php
@@ -53,7 +53,7 @@ class Application extends BaseApplication
     }
 
     /**
-     * @return Composer
+     * @return \Composer\Composer
      */
     public function getComposer($required = true, $config = null)
     {
@@ -68,6 +68,14 @@ class Application extends BaseApplication
 
         return $this->composer;
     }
+
+	/**
+	 * @return Factory
+	 */
+	public function getComposerFactory()
+	{
+		return new Factory();
+	}
 
     /**
      * Initializes all the composer commands

--- a/src/Composer/Satis/Console/Application.php
+++ b/src/Composer/Satis/Console/Application.php
@@ -69,13 +69,13 @@ class Application extends BaseApplication
         return $this->composer;
     }
 
-	/**
-	 * @return Factory
-	 */
-	public function getComposerFactory()
-	{
-		return new Factory();
-	}
+    /**
+     * @return Factory
+     */
+    public function getComposerFactory()
+    {
+        return new Factory();
+    }
 
     /**
      * Initializes all the composer commands

--- a/src/Composer/Satis/Console/Application.php
+++ b/src/Composer/Satis/Console/Application.php
@@ -59,7 +59,7 @@ class Application extends BaseApplication
     {
         if (null === $this->composer) {
             try {
-                $this->composer = Factory::create($this->io, $config);
+                $this->composer = $this->getComposerFactory()->create($this->io, $config);
             } catch (\InvalidArgumentException $e) {
                 $this->io->write($e->getMessage());
                 exit(1);


### PR DESCRIPTION
This is very handy if you need to customize behaviour of Satis, such as defining new types of repositories or downloaders for some private repositories.

Recreated PR https://github.com/composer/satis/pull/212