### PR TITLE
allow multiple build releases for same Version

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -242,11 +242,11 @@ EOT
                         }
 
                         // add matching package if not yet selected
-                        if (!isset($selected[$package->getUniqueName()])) {
+                        if (!isset($selected[$package->getPrettyVersion()])) {
                             if ($verbose) {
                                 $output->writeln('Selected '.$package->getPrettyName().' ('.$package->getPrettyVersion().')');
                             }
-                            $selected[$package->getUniqueName()] = $package;
+                            $selected[$package->getPrettyVersion()] = $package;
                         }
                     }
                 }


### PR DESCRIPTION
before 1.2.3+patch1 and 1.2.3+patch2 could not both exist, always the
first occurence was used. It even conflicted with 1.2.3