### PR TITLE
Prettified console output

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -370,7 +370,7 @@ EOT
                 continue;
             }
 
-            $name = $package->getName();
+            $name = $package->getPrettyString();
 
             if (true === $skipDev && true === $package->isDev()) {
                 $output->writeln(sprintf("<info>Skipping '%s' (is dev)</info>", $name));


### PR DESCRIPTION
Shows somewhat more verbose information about a package being dumped or
skipped, to prevent repositories with many branches just showing the
same over and over. Should solve #252