### PR TITLE
Reimplemented PR#232, PR#110

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.settings
 /.project
+/.idea
 /.buildpath
 /satis.phar
 /vendor

--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -40,6 +40,7 @@ class BuildCommand extends Command
                 new InputArgument('file', InputArgument::OPTIONAL, 'Json file to use', './satis.json'),
                 new InputArgument('output-dir', InputArgument::OPTIONAL, 'Location where to output built files', null),
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Packages that should be built, if not provided all packages are.', null),
+                new InputOption('repository-url', null, InputOption::VALUE_OPTIONAL, 'Only update the repository at given url', null),
                 new InputOption('no-html-output', null, InputOption::VALUE_NONE, 'Turn off HTML view'),
                 new InputOption('skip-errors', null, InputOption::VALUE_NONE, 'Skip Download or Archive errors'),
             ))
@@ -91,7 +92,12 @@ EOT
         $verbose = $input->getOption('verbose');
         $configFile = $input->getArgument('file');
         $packagesFilter = $input->getArgument('packages');
+        $repositoryUrl = $input->getOption('repository-url');
         $skipErrors = (bool) $input->getOption('skip-errors');
+
+        if ($repositoryUrl !== null && count($packagesFilter) > 0) {
+            throw new \InvalidArgumentException('Package and repository-url argument can not be used together.');
+        }
 
         // load auth.json authentication information and pass it to the io interface
         $io = $this->getIO();
@@ -124,7 +130,13 @@ EOT
 
         $composer = $this->getApplication()->getComposer(true, $config);
         $packageSelection = new PackageSelection($output, $outputDir, $config, $skipErrors);
-        $packageSelection->setPackagesFilter($packagesFilter);
+
+        if($repositoryUrl !== null) {
+            $packageSelection->setRepositoryFilter($repositoryUrl);
+        } else {
+            $packageSelection->setPackagesFilter($packagesFilter);
+        }
+
         $packages = $packageSelection->select($composer, $verbose);
 
         if (isset($config['archive']['directory'])) {

--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -96,7 +96,7 @@ EOT
         $skipErrors = (bool) $input->getOption('skip-errors');
 
         if ($repositoryUrl !== null && count($packagesFilter) > 0) {
-            throw new \InvalidArgumentException('Package and repository-url argument can not be used together.');
+            throw new \InvalidArgumentException('The arguments "package" and "repository-url" can not be used together.');
         }
 
         // load auth.json authentication information and pass it to the io interface
@@ -131,7 +131,7 @@ EOT
         $composer = $this->getApplication()->getComposer(true, $config);
         $packageSelection = new PackageSelection($output, $outputDir, $config, $skipErrors);
 
-        if($repositoryUrl !== null) {
+        if ($repositoryUrl !== null) {
             $packageSelection->setRepositoryFilter($repositoryUrl);
         } else {
             $packageSelection->setPackagesFilter($packagesFilter);

--- a/src/Composer/Satis/PackageSelection/PackageSelection.php
+++ b/src/Composer/Satis/PackageSelection/PackageSelection.php
@@ -171,8 +171,8 @@ class PackageSelection
             }
         }
 
-        if($this->hasRepositoryFilter() && count($repos) !== 1) {
-            throw new \InvalidArgumentException(sprintf('Specified repository url %s does not exist.', $this->repositoryFilter));
+        if ($this->hasRepositoryFilter() && count($repos) !== 1) {
+            throw new \InvalidArgumentException(sprintf('Specified repository url "%s" does not exist.', $this->repositoryFilter));
         }
 
         $links = $this->requireAll ? $this->getAllLinks($repos, $this->minimumStability, $verbose) : $this->getFilteredLinks($composer);


### PR DESCRIPTION
This is reimplemented https://github.com/composer/satis/pull/232, which also closes https://github.com/composer/satis/pull/110.

This allows for building a single package by it's url address, e.g.

```
php bin/satis build satis.json public --repository-url https://github.com/realshadow/serializers.git
```

Building by specifying both - `package` and `repository-url` argument is not possible and should be used separately.

Can someone please look at this? 

Thanks