### PR TITLE
Remove global repositories and download archive files in own directory

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -164,7 +164,10 @@ EOT
         }
 
         $packagesBuilder = new PackagesBuilder($output, $outputDir, $config, $skipErrors);
-        $packagesBuilder->dump($packages);
+        $updated = $packagesBuilder->dump($packages);
+        if (!$updated) {
+            return;
+        }
 
         if ($htmlView = !$input->getOption('no-html-output')) {
             $htmlView = !isset($config['output-html']) || $config['output-html'];

--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -130,7 +130,7 @@ EOT
             if (isset($config['output-dir'])) {
                 $outputDir = $config['output-dir'];
             } elseif (Filesystem::isLocalPath($configFile)) {
-                $outputDir = dirname($configFile);
+                $outputDir = dirname(realpath($configFile));
             }
         }
 

--- a/src/Composer/Satis/PackageSelection/PackageSelection.php
+++ b/src/Composer/Satis/PackageSelection/PackageSelection.php
@@ -394,7 +394,7 @@ class PackageSelection
     private function getAllLinks($repos, $minimumStability, $verbose)
     {
         $links = array();
-        $depsLinks = [];
+        $depsLinks = array();
 
         foreach ($repos as $repo) {
             // collect links for composer repos with providers

--- a/tests/Composer/Test/Satis/PackagesBuilderDumpTest.php
+++ b/tests/Composer/Test/Satis/PackagesBuilderDumpTest.php
@@ -84,9 +84,9 @@ class PackagesBuilderDumpTest extends \PHPUnit_Framework_TestCase
             'repositories' => array(array('type' => 'composer', 'url' => 'http://localhost:54715')),
             'require' => array('vendor/name' => '*'),
             'homepage' => 'http://localhost',
-            'archive' => [
+            'archive' => array(
                 'directory' => 'p'
-            ]
+            )
         ), false);
         $packages = array(
             $this->package,

--- a/tests/Composer/Test/Satis/PackagesBuilderDumpTest.php
+++ b/tests/Composer/Test/Satis/PackagesBuilderDumpTest.php
@@ -33,7 +33,6 @@ class PackagesBuilderDumpTest extends \PHPUnit_Framework_TestCase
 
         $this->root = vfsStream::setup('build');
     }
-
     public function testNominalCase()
     {
         $arrayPackage = array(
@@ -66,6 +65,52 @@ class PackagesBuilderDumpTest extends \PHPUnit_Framework_TestCase
         $packagesIncludeJson = JsonFile::parseJson($this->root->getChild($includeJsonFile)->getContent());
         $this->assertEquals($arrayPackage, $packagesIncludeJson['packages']);
         $this->assertArrayNotHasKey('notify-batch', $packagesJson);
+    }
+    
+    public function testArchive()
+    {
+        $arrayPackage = array(
+            "vendor/name" => array(
+                "1.0" => array(
+                    "name" => "vendor/name",
+                    "version" => "1.0",
+                    "version_normalized" => "1.0.0.0",
+                    "type" => "library",
+                ),
+            ),
+        );
+
+        $packagesBuilder = new PackagesBuilder(new NullOutput(), vfsStream::url('build'), array(
+            'repositories' => array(array('type' => 'composer', 'url' => 'http://localhost:54715')),
+            'require' => array('vendor/name' => '*'),
+            'homepage' => 'http://localhost',
+            'archive' => [
+                'directory' => 'p'
+            ]
+        ), false);
+        $packages = array(
+            $this->package,
+        );
+
+        $packagesBuilder->dump($packages);
+
+        $packagesJson = JsonFile::parseJson($this->root->getChild('build/packages.json')->getContent());
+        $this->assertArrayNotHasKey('notify-batch', $packagesJson);
+
+        foreach ($packagesJson['provider-includes'] as $key => $hash) {
+            $file = 'build/' . str_replace('%hash%', $hash['sha256'], $key);
+            $this->assertTrue(is_file(vfsStream::url($file)));
+            $providerJson = JsonFile::parseJson($this->root->getChild($file)->getContent());
+            foreach ($providerJson['providers'] as $package => $hash) {
+                $file = 'build' . strtr($packagesJson['providers-url'], array(
+                    '%package%' => $package,
+                    '%hash%' => $hash['sha256']
+                ));
+                $this->assertTrue(is_file(vfsStream::url($file)));
+                $json = JsonFile::parseJson($this->root->getChild($file)->getContent());
+                $this->assertTrue(isset($json['packages'][$package]));
+            }
+        }
     }
 
     public function testNotifyBatch()

--- a/tests/Composer/Test/Satis/WebBuilderDumpTest.php
+++ b/tests/Composer/Test/Satis/WebBuilderDumpTest.php
@@ -59,6 +59,9 @@ class WebBuilderDumpTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('/<title>dummy root package Composer Repository<\/title>/', $html);
         $this->assertRegExp('/<h3 id="vendor\/name">vendor\/name<\/h3>/', $html);
         $this->assertFalse((bool) preg_match('/<p class="abandoned">/', $html));
+
+        $content = $this->root->getChild('build/styles.css')->getContent();
+        $this->assertRegExp('/Satis stylesheet/', $content);
     }
 
     public function testRepositoryWithNoName()

--- a/views/index.html.twig
+++ b/views/index.html.twig
@@ -4,9 +4,7 @@
     <meta charset="utf-8" />
     <meta name="robots" content="noindex,nofollow" />
     <title>{{ name }} Composer Repository</title>
-    <style type="text/css">
-    {% include 'styles.css' %}
-    </style>
+    <link href="{{url}}/styles.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>
 
@@ -135,9 +133,9 @@
         </div>
     </div>
 
+<script src="{{url}}/jquery-2.0.0.js"></script>
+<script src="{{url}}/moment-2.4.0.js"></script>
     <script>
-    {% include 'jquery-2.0.0.js' %}
-    {% include 'moment-2.4.0.js' %}
     $(function(){
         var packages = $('h3');
         var timer;


### PR DESCRIPTION
satis won't add dependencies of repositories when require-all is on. This patch fixed it.
I prefer seperate include files for every package instead of all in one, like packagist.org does.
So archive files and provider-includes files are in their own directory for package.