### PR TITLE
Clean folders

### DIFF
--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -33,6 +33,10 @@
             "additionalProperties": false,
             "required": ["directory"],
             "properties": {
+                "autoclean": {
+                    "type": "boolean",
+                    "description": "If true, will remove all unused files."
+                },
                 "directory": {
                     "type": "string",
                     "description": "The location of the dist files."

--- a/src/Composer/Satis/Builder/ArchiveBuilder.php
+++ b/src/Composer/Satis/Builder/ArchiveBuilder.php
@@ -101,11 +101,19 @@ class ArchiveBuilder extends Builder implements BuilderInterface
                 if (!$this->skipErrors) {
                     throw $exception;
                 }
+
+                //If file exists then exclude it
+                $packageName = $archiveManager->getPackageFilename($package);
+                if ('pear-library' === $package->getType()) {
+                    $excludeFiles[] = $packageName.'.'. pathinfo($package->getDistUrl(), PATHINFO_EXTENSION);
+                } else {
+                    $excludeFiles[] = $packageName . '.' . $format;
+                }
                 $this->output->writeln(sprintf("<error>Skipping Exception '%s'.</error>", $exception->getMessage()));
             }
         }
 
-        $this->clean($directory, $excludeFiles);
+        $this->clean($directory, array_unique($excludeFiles));
     }
 
     /**

--- a/src/Composer/Satis/Builder/ArchiveBuilder.php
+++ b/src/Composer/Satis/Builder/ArchiveBuilder.php
@@ -55,6 +55,7 @@ class ArchiveBuilder extends Builder implements BuilderInterface
         $archiveManager->setOverwriteFiles(false);
 
         shuffle($packages);
+        $excludeFiles = array();
         /* @var \Composer\Package\CompletePackage $package */
         foreach ($packages as $package) {
             if ($helper->isSkippable($package)) {
@@ -86,6 +87,7 @@ class ArchiveBuilder extends Builder implements BuilderInterface
                     $archiveFormat = $format;
                 }
                 $archive = basename($path);
+                $excludeFiles[] = $archive;
                 $distUrl = sprintf('%s/%s/%s', $endpoint, $this->config['archive']['directory'], $archive);
                 $package->setDistType($archiveFormat);
                 $package->setDistUrl($distUrl);
@@ -102,6 +104,8 @@ class ArchiveBuilder extends Builder implements BuilderInterface
                 $this->output->writeln(sprintf("<error>Skipping Exception '%s'.</error>", $exception->getMessage()));
             }
         }
+
+        $this->clean($directory, $excludeFiles);
     }
 
     /**

--- a/src/Composer/Satis/Builder/ArchiveBuilder.php
+++ b/src/Composer/Satis/Builder/ArchiveBuilder.php
@@ -113,7 +113,7 @@ class ArchiveBuilder extends Builder implements BuilderInterface
             }
         }
 
-        $this->clean($directory, array_unique($excludeFiles));
+        $this->removeAllBut($directory, array_unique($excludeFiles));
     }
 
     /**

--- a/src/Composer/Satis/Builder/Builder.php
+++ b/src/Composer/Satis/Builder/Builder.php
@@ -53,11 +53,19 @@ class Builder
      *
      * @param string          $directory    Directory to clean
      * @param string|string[] $excludeFiles File list to exclude
+     * @param bool            $forceRemove  Forcibly remove files
      *
      * @return void
      */
-    protected function clean($directory, $excludeFiles)
+    protected function removeAllBut($directory, $excludeFiles, $forceRemove = false)
     {
+        $isRemove = $forceRemove ||
+                    (isset($this->config['archive']['autoclean']) && true === $this->config['archive']['autoclean']);
+
+        if (!$isRemove) {
+            return;
+        }
+
         $files = scandir($directory);
         if (!is_array($excludeFiles)) {
             $excludeFiles = (array) $excludeFiles;

--- a/src/Composer/Satis/Builder/Builder.php
+++ b/src/Composer/Satis/Builder/Builder.php
@@ -64,7 +64,7 @@ class Builder
         }
 
         foreach (array_diff($files, $excludeFiles) as $file) {
-            if (in_array($file, ['.', '..'])) {
+            if (in_array($file, array('.', '..'))) {
                 continue;
             }
 

--- a/src/Composer/Satis/Builder/Builder.php
+++ b/src/Composer/Satis/Builder/Builder.php
@@ -47,4 +47,29 @@ class Builder
         $this->config = $config;
         $this->skipErrors = (bool) $skipErrors;
     }
+
+    /**
+     * Remove from $directory all files excluding $excludeFiles
+     *
+     * @param string          $directory    Directory to clean
+     * @param string|string[] $excludeFiles File list to exclude
+     *
+     * @return void
+     */
+    protected function clean($directory, $excludeFiles)
+    {
+        $files = scandir($directory);
+        if (!is_array($excludeFiles)) {
+            $excludeFiles = (array) $excludeFiles;
+        }
+
+        foreach (array_diff($files, $excludeFiles) as $file) {
+            if (in_array($file, ['.', '..'])) {
+                continue;
+            }
+
+            $this->output->writeln("<info>remove $directory/$file</info>");
+            unlink("$directory/$file");
+        }
+    }
 }

--- a/src/Composer/Satis/Builder/PackagesBuilder.php
+++ b/src/Composer/Satis/Builder/PackagesBuilder.php
@@ -83,6 +83,8 @@ class PackagesBuilder extends Builder implements BuilderInterface
         rename($this->filenamePrefix, $filenameWithHash);
         $this->output->writeln("<info>wrote packages json $filenameWithHash</info>");
 
+        $this->clean($this->outputDir . '/include', $filenameWithHash);
+
         return $filenameWithHash;
     }
 

--- a/src/Composer/Satis/Builder/PackagesBuilder.php
+++ b/src/Composer/Satis/Builder/PackagesBuilder.php
@@ -83,7 +83,8 @@ class PackagesBuilder extends Builder implements BuilderInterface
         rename($this->filenamePrefix, $filenameWithHash);
         $this->output->writeln("<info>wrote packages json $filenameWithHash</info>");
 
-        $this->removeAllBut($this->outputDir . '/include', "all\$$hash.json");
+        $forceRemove = true;
+        $this->removeAllBut($this->outputDir . '/include', "all\$$hash.json", $forceRemove);
 
         return $filenameWithHash;
     }

--- a/src/Composer/Satis/Builder/PackagesBuilder.php
+++ b/src/Composer/Satis/Builder/PackagesBuilder.php
@@ -83,7 +83,7 @@ class PackagesBuilder extends Builder implements BuilderInterface
         rename($this->filenamePrefix, $filenameWithHash);
         $this->output->writeln("<info>wrote packages json $filenameWithHash</info>");
 
-        $this->clean($this->outputDir . '/include', $filenameWithHash);
+        $this->clean($this->outputDir . '/include', "all\$$hash.json");
 
         return $filenameWithHash;
     }

--- a/src/Composer/Satis/Builder/PackagesBuilder.php
+++ b/src/Composer/Satis/Builder/PackagesBuilder.php
@@ -83,7 +83,7 @@ class PackagesBuilder extends Builder implements BuilderInterface
         rename($this->filenamePrefix, $filenameWithHash);
         $this->output->writeln("<info>wrote packages json $filenameWithHash</info>");
 
-        $this->clean($this->outputDir . '/include', "all\$$hash.json");
+        $this->removeAllBut($this->outputDir . '/include', "all\$$hash.json");
 
         return $filenameWithHash;
     }


### PR DESCRIPTION
Hello. I want to propose changes to the code.

In our project we are faced with fact that when downloading all dependencies, the archives for versions which were removed from vcs are still present in output directory.

Also same problem present with "include/all$%hash%.json" files. These files are not removed after each build.