### PR TITLE
add support configuring include filename

### DIFF
--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -105,6 +105,10 @@
             "type": "boolean",
             "description": "If true, resolve and add all Dev dependencies of each required package."
         },
+        "include-filename": {
+            "type": "string",
+            "description": "Specify filename instead of default include/all${SHA1_HASH}.json"
+        },
         "output-dir": {
             "type": "string",
             "description": "The directory where the static Repository is built."

--- a/src/Composer/Satis/Builder/PackagesBuilder.php
+++ b/src/Composer/Satis/Builder/PackagesBuilder.php
@@ -11,7 +11,6 @@
 
 namespace Composer\Satis\Builder;
 
-use Composer\Composer;
 use Composer\Json\JsonFile;
 use Composer\Package\Dumper\ArrayDumper;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -23,11 +22,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class PackagesBuilder extends Builder implements BuilderInterface
 {
-    /** @var string prefix of included json files. */
-    private $filenamePrefix;
-
     /** @var string packages.json file name. */
     private $filename;
+
+    /** @var string included json filename template */
+    private $includeFileName;
 
     /**
      * Dedicated Packages Constructor.
@@ -41,8 +40,8 @@ class PackagesBuilder extends Builder implements BuilderInterface
     {
         parent::__construct($output, $outputDir, $config, $skipErrors);
 
-        $this->filenamePrefix = $this->outputDir.'/include/all';
         $this->filename = $this->outputDir.'/packages.json';
+        $this->includeFileName = isset($config['include-filename']) ? $config['include-filename'] : 'include/all${sha1}.json';
     }
 
     /**
@@ -52,13 +51,7 @@ class PackagesBuilder extends Builder implements BuilderInterface
      */
     public function dump(array $packages)
     {
-        $packageFile = $this->dumpPackageIncludeJson($packages);
-        $packageFileHash = hash_file('sha1', $packageFile);
-
-        $includes = array(
-            'include/all$'.$packageFileHash.'.json' => array('sha1' => $packageFileHash),
-        );
-
+        $includes = $this->dumpPackageIncludeJson($packages);
         $this->dumpPackagesJson($includes);
     }
 
@@ -67,7 +60,7 @@ class PackagesBuilder extends Builder implements BuilderInterface
      *
      * @param array $packages List of packages to dump
      *
-     * @return string $filenameWithHash Includes JSON file name
+     * @return array Definition of "includes" block for packages.json
      */
     private function dumpPackageIncludeJson(array $packages)
     {
@@ -76,14 +69,25 @@ class PackagesBuilder extends Builder implements BuilderInterface
         foreach ($packages as $package) {
             $repo['packages'][$package->getName()][$package->getPrettyVersion()] = $dumper->dump($package);
         }
-        $repoJson = new JsonFile($this->filenamePrefix);
-        $repoJson->write($repo);
-        $hash = hash_file('sha1', $this->filenamePrefix);
-        $filenameWithHash = $this->filenamePrefix.'$'.$hash.'.json';
-        rename($this->filenamePrefix, $filenameWithHash);
-        $this->output->writeln("<info>wrote packages json $filenameWithHash</info>");
 
-        return $filenameWithHash;
+        // dump to temporary file
+        $tempFilename = $this->outputDir.'/$include.json';
+        $repoJson = new JsonFile($tempFilename);
+        $repoJson->write($repo);
+
+        // rename file accordingly
+        $includeFileHash = hash_file('sha1', $tempFilename);
+        $includeFileName = str_replace(
+            '{sha1}', $includeFileHash, $this->includeFileName
+        );
+        rename($tempFilename, $this->outputDir.'/'.$includeFileName);
+        $this->output->writeln("<info>Wrote packages json $includeFileName</info>");
+
+        $includes = array(
+            $includeFileName => array('sha1' => $includeFileHash),
+        );
+
+        return $includes;
     }
 
     /**

--- a/src/Composer/Satis/Builder/PackagesBuilder.php
+++ b/src/Composer/Satis/Builder/PackagesBuilder.php
@@ -13,6 +13,7 @@ namespace Composer\Satis\Builder;
 
 use Composer\Json\JsonFile;
 use Composer\Package\Dumper\ArrayDumper;
+use Composer\Util\Filesystem;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -80,7 +81,9 @@ class PackagesBuilder extends Builder implements BuilderInterface
         $includeFileName = str_replace(
             '{sha1}', $includeFileHash, $this->includeFileName
         );
-        rename($tempFilename, $this->outputDir.'/'.$includeFileName);
+        $fs = new Filesystem();
+        $fs->ensureDirectoryExists(dirname($this->outputDir.'/'.$includeFileName));
+        $fs->rename($tempFilename, $this->outputDir.'/'.$includeFileName);
         $this->output->writeln("<info>Wrote packages json $includeFileName</info>");
 
         $includes = array(

--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -88,6 +88,8 @@ The json config file accepts the following keys:
 - <info>"notify-batch"</info>: Allows you to specify a URL that will
   be called every time a user installs a package, see
   https://getcomposer.org/doc/05-repositories.md#notify-batch
+- <info>"include-filename"</info> Specify filename instead of default include/all\${SHA1_HASH}.json
+
 EOT
             );
     }


### PR DESCRIPTION
this solves problem that includes/ dir grows with stale json files by allowing to configure fixed name:

```json
{
    "name": "...",
    "description": "...",
    "include-filename": "all.json",
    "repositories": [
```


```
$ satis/bin/satis build satis.json dist
Scanning packages
Initializing PEAR repository http://pear.php.net
Wrote packages json all.json
Writing packages.json
Writing web view
```

ps: side effect is that `hash_file` is no longer called twice ;)