### PR TITLE
Add sample Dockerfile, close composer#228

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM php:5.6
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y git zlib1g-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && docker-php-ext-install zip \
+    && echo "date.timezone = UTC" > /usr/local/etc/php/php.ini
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer \
+    && composer create-project composer/satis --stability=dev --no-dev
+
+WORKDIR /build
+ENTRYPOINT ["/satis/bin/satis"]


### PR DESCRIPTION
The Dockerfile is based on [Docker Hub's official PHP 5.6 image](https://hub.docker.com/_/php/)

To build the Dockerfile into an image
```
$ docker build -t composer/satis .
```

To use the satis image
```
$ docker run --rm -v /path/to/satis-conf-root:/build composer/satis build satis.json /build/output
Scanning packages
Wrote packages json ...
Writing packages.json
Writing web view
$ ls /path/to/satis-conf-root/output
include  index.html  packages.json
```