### PR TITLE
Renamed composer Command to BaseCommand

### DIFF
--- a/src/Composer/Satis/Command/AddCommand.php
+++ b/src/Composer/Satis/Command/AddCommand.php
@@ -17,14 +17,14 @@ use Composer\Repository\VcsRepository;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
-use Composer\Command\Command;
+use Composer\Command\BaseCommand;
 use Composer\Config;
 use Composer\Json\JsonFile;
 
 /**
  * @author Sergey Kolodyazhnyy <sergey.kolodyazhnyy@gmail.com>
  */
-class AddCommand extends Command
+class AddCommand extends BaseCommand
 {
     protected function configure()
     {

--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -11,7 +11,7 @@
 
 namespace Composer\Satis\Command;
 
-use Composer\Command\Command;
+use Composer\Command\BaseCommand;
 use Composer\Composer;
 use Composer\Config;
 use Composer\Config\JsonConfigSource;
@@ -33,7 +33,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-class BuildCommand extends Command
+class BuildCommand extends BaseCommand
 {
     protected function configure()
     {

--- a/src/Composer/Satis/Command/InitCommand.php
+++ b/src/Composer/Satis/Command/InitCommand.php
@@ -16,14 +16,14 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
-use Composer\Command\Command;
+use Composer\Command\BaseCommand;
 use Composer\Config;
 use Composer\Json\JsonFile;
 
 /**
  * @author Sergey Kolodyazhnyy <sergey.kolodyazhnyy@gmail.com>
  */
-class InitCommand extends Command
+class InitCommand extends BaseCommand
 {
 
     protected function configure()

--- a/src/Composer/Satis/Command/PurgeCommand.php
+++ b/src/Composer/Satis/Command/PurgeCommand.php
@@ -11,13 +11,13 @@
 
 namespace Composer\Satis\Command;
 
-use Composer\Command\Command;
+use Composer\Command\BaseCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Composer\Json\JsonFile;
 
-class PurgeCommand extends Command
+class PurgeCommand extends BaseCommand
 {
     protected function configure()
     {


### PR DESCRIPTION
Few days ago satis broke on my installation. Composer change base class for commands from *Composer\Command\Command* to *Composer\Command\BaseCommand*

I have changed use statements in commands

Fix #303 