### PR TITLE
`tags-path` and `branches-path` JSON schema update

### DIFF
--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -95,7 +95,7 @@
                         "format": "uri"
                     },
                     "branches-path" : {
-                        "type": ["string","array"],
+                        "type": ["string","array","boolean"],
                         "description": "Single or array of relative paths to the Repository's Branches directories.",
                         "items": {
                             "type": "string",
@@ -107,7 +107,7 @@
                         "description": "Relative path to the Repository's Trunk directory."
                     },
                     "tags-path" : {
-                        "type": ["string","array"],
+                        "type": ["string","array","boolean"],
                         "description": "Single or array of relative paths to the Repository's Tags directories.",
                         "items": {
                             "type": "string",

--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -78,7 +78,44 @@
         "repositories": {
             "type": ["object", "array"],
             "description": "A set of additional repositories where packages can be found.",
-            "additionalProperties": true
+            "additionalProperties": true,
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["type","url"],
+                "properties": {
+                    "type" : {
+                        "type": "string",
+                        "description": "Version control system type",
+                        "enum": ["vcs","svn","git","hg"]
+                    },
+                    "url" : {
+                        "type": "string",
+                        "description": "URL for the Repository.",
+                        "format": "uri"
+                    },
+                    "branches-path" : {
+                        "type": ["string","array"],
+                        "description": "Single or array of relative paths to the Repository's Branches directories.",
+                        "items": {
+                            "type": "string",
+                            "additionalProperties": false
+                        }
+                    },
+                    "trunk-path" : {
+                        "type": "string",
+                        "description": "Relative path to the Repository's Trunk directory."
+                    },
+                    "tags-path" : {
+                        "type": ["string","array"],
+                        "description": "Single or array of relative paths to the Repository's Tags directories.",
+                        "items": {
+                            "type": "string",
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            }
         },
         "minimum-stability": {
             "type": ["string"],


### PR DESCRIPTION
Implemented JSON schema update to validate the `tags-path` and `branches-path` configuration clauses, also enabled the possibility of using arrays for both path configurations.

This Pull Request relates to: https://github.com/composer/satis/issues/312 and https://github.com/composer/composer/pull/5142