### PR TITLE
Add build command "stats" option to display a progress bar.

### DIFF
--- a/src/Composer/Satis/Command/BuildCommand.php
+++ b/src/Composer/Satis/Command/BuildCommand.php
@@ -47,6 +47,7 @@ class BuildCommand extends BaseCommand
                 new InputOption('repository-url', null, InputOption::VALUE_OPTIONAL, 'Only update the repository at given url', null),
                 new InputOption('no-html-output', null, InputOption::VALUE_NONE, 'Turn off HTML view'),
                 new InputOption('skip-errors', null, InputOption::VALUE_NONE, 'Skip Download or Archive errors'),
+                new InputOption('stats', null, InputOption::VALUE_NONE, 'Display the download progress bar'),
             ))
             ->setHelp(<<<EOT
 The <info>build</info> command reads the given json file
@@ -183,6 +184,7 @@ EOT
         if (isset($config['archive']['directory'])) {
             $downloads = new ArchiveBuilder($output, $outputDir, $config, $skipErrors);
             $downloads->setComposer($composer);
+            $downloads->setInput($input);
             $downloads->dump($packages);
         }
 


### PR DESCRIPTION
This will hide all messages like "Dumping foo/bar..." to show a progress bar instead.

Example :

```
Scanning packages
Creating local downloads in 'web/dist'
  1/86 [>---------------------------]   1% - Installing foo/bar (dev-master)
```

The verbosity override the option : if the build command is executed with `-v(vv)` option, the `stats` option will be disabled.
Useful when having a lot of packages.