### PR TITLE
fix exception during purge command when nothing is needed

### DIFF
--- a/src/Composer/Satis/Command/PurgeCommand.php
+++ b/src/Composer/Satis/Command/PurgeCommand.php
@@ -84,7 +84,7 @@ EOT
         }
         $length = strlen($prefix);
 
-        $needed = null;
+        $needed = array();
         foreach ($json['packages'] as $package) {
             foreach ($package as $version) {
                 if (!isset($version['dist']['url'])) {


### PR DESCRIPTION
Wile playing with a fresh SATIS instance I came across this error:

```
ErrorException: array_diff(): Argument #2 is not an array

Exception trace:
 () at /data/Projects/satis/vendor/composer/satis/src/Composer/Satis/Command/PurgeCommand.php:111
 Composer\Util\ErrorHandler::handle() at n/a:n/a
 array_diff() at /data/Projects/satis/vendor/composer/satis/src/Composer/Satis/Command/PurgeCommand.php:111
 Composer\Satis\Command\PurgeCommand->execute() at /data/Projects/satis/vendor/symfony/console/Command/Command.php:256
 Symfony\Component\Console\Command\Command->run() at /data/Projects/satis/vendor/symfony/console/Application.php:815
 Symfony\Component\Console\Application->doRunCommand() at /data/Projects/satis/vendor/symfony/console/Application.php:186
 Symfony\Component\Console\Application->doRun() at /data/Projects/satis/vendor/composer/satis/src/Composer/Satis/Console/Application.php:53
 Composer\Satis\Console\Application->doRun() at /data/Projects/satis/vendor/symfony/console/Application.php:117
 Symfony\Component\Console\Application->run() at /data/Projects/satis/vendor/composer/satis/bin/satis:9
```