### PR TITLE
PHP Version Requirement In README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Fork the project, create a feature branch, and send us a pull request.
 Requirements
 ------------
 
-PHP 5.5+
+PHP 5.6+
 
 Authors
 -------


### PR DESCRIPTION
The README currently states that the PHP requirement is 5.5+ when the actual requirement, as set in the `composer.json`, is 5.6+