### PR TITLE
Docker tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,14 +24,14 @@ RUN curl -s -f -L -o /tmp/composer-setup.php https://getcomposer.org/installer \
 
 WORKDIR /satis
 
-ADD ["composer.json", "composer.lock", "/satis/"]
+COPY ["composer.json", "composer.lock", "/satis/"]
 
 RUN composer install --no-interaction --no-ansi --no-autoloader --no-scripts --no-plugins --no-dev
 
-ADD /bin /satis/bin/
-ADD /res /satis/res/
-ADD /views /satis/views/
-ADD /src /satis/src/
+COPY /bin /satis/bin/
+COPY /res /satis/res/
+COPY /views /satis/views/
+COPY /src /satis/src/
 
 RUN composer dump-autoload --no-interaction --no-ansi --optimize --no-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM php:7-alpine
 
+MAINTAINER https://github.com/composer/satis
+
 RUN apk --no-cache add curl git subversion openssh openssl mercurial tini
 
 RUN echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/memory-limit.ini \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ MAINTAINER https://github.com/composer/satis
 
 RUN apk --no-cache add curl git subversion openssh openssl mercurial tini
 
-RUN echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/memory-limit.ini \
- && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > $PHP_INI_DIR/conf.d/date_timezone.ini
+RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
+ && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"
 
 ENV COMPOSER_HOME /composer
-ENV PATH /composer/vendor/bin:$PATH
+ENV PATH "/composer/vendor/bin:$PATH"
 ENV COMPOSER_ALLOW_SUPERUSER 1
 RUN curl -s -f -L -o /tmp/composer-setup.php https://getcomposer.org/installer \
  && curl -s -f -L -o /tmp/composer-setup.sig https://composer.github.io/installer.sig \


### PR DESCRIPTION
- COPY instead of ADD

  For other items (files, directories) that do not require ADD’s tar
  auto-extraction capability, you should always use COPY.

- add MAINTAINER

- double quote to prevent globbing and word splitting