### PR TITLE
Fix fatal errors

### DIFF
--- a/src/Console/Command/PurgeCommand.php
+++ b/src/Console/Command/PurgeCommand.php
@@ -16,8 +16,6 @@ use Composer\Json\JsonFile;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Input\InputArgument;
-use Composer\Json\JsonFile;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 


### PR DESCRIPTION
Fixes the following fatal errors:
```shell
PHP Fatal error:  Cannot use Symfony\Component\Console\Input\InputArgument as InputArgument because the name is already in use in /path/to/satis/src/Console/Command/PurgeCommand.php
```
```shell
PHP Fatal error:  Cannot use Composer\Json\JsonFile as JsonFile because the name is already in use in /path/to/satis/src/Console/Command/PurgeCommand.php
```