### PR TITLE
Remove duplicate line

### DIFF
--- a/src/Console/Command/PurgeCommand.php
+++ b/src/Console/Command/PurgeCommand.php
@@ -16,7 +16,6 @@ use Composer\Json\JsonFile;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Input\InputArgument;
 use Composer\Json\JsonFile;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;


### PR DESCRIPTION
Fixes : 
```php
PHP Fatal error:  Cannot use Symfony\Component\Console\Input\InputArgument as InputArgument because the name is already in use in src/Console/Command/PurgeCommand.php on line 19
```