### PR TITLE
Fix the disabling of Packagist

### DIFF
--- a/src/Console/Command/BuildCommand.php
+++ b/src/Console/Command/BuildCommand.php
@@ -158,7 +158,7 @@ EOT
         }
 
         // disable packagist by default
-        unset(Config::$defaultRepositories['packagist']);
+        unset(Config::$defaultRepositories['packagist'], Config::$defaultRepositories['packagist.org']);
 
         if (!$outputDir = $input->getArgument('output-dir')) {
             $outputDir = isset($config['output-dir']) ? $config['output-dir'] : null;


### PR DESCRIPTION
The key in the array was renamed in Composer at some point (and this array is not part of the public API of composer covered by semver, as any programmatic API currently)