### PR TITLE
Added possibility to view the keywords as specified in composer.json file

### DIFF
--- a/src/Builder/WebBuilder.php
+++ b/src/Builder/WebBuilder.php
@@ -56,6 +56,7 @@ class WebBuilder extends Builder
             'name' => $name,
             'url' => $this->rootPackage->getHomepage(),
             'description' => $this->rootPackage->getDescription(),
+            'keywords' => $this->rootPackage->getKeywords(),
             'packages' => $mappedPackages,
             'dependencies' => $this->dependencies,
         ]);

--- a/views/package.html.twig
+++ b/views/package.html.twig
@@ -29,6 +29,13 @@
         {% if package.highest.description %}
         <p class="lead">{{ package.highest.description }}</p>
         {% endif %}
+        
+        {% if package.highest.keywords %}
+        <div class="row">
+            <div class="col-xs-2 text-xs-left text-sm-right"><strong>Keywords</strong></div>
+            <div class="col-xs-12 col-sm-10">{{ package.highest.keywords|join(', ') }}</div>
+        </div>
+        {% endif %}
 
         {% if package.highest.homepage %}
         <div class="row">


### PR DESCRIPTION
As described in https://getcomposer.org/doc/04-schema.md#keywords, the composer.json file can have an array of keywords.
This pull requests parses the keywords and shows them in the web view.