### PR TITLE
Fix unnecessary array in JSON schema

### DIFF
--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -81,7 +81,7 @@
             "additionalProperties": true
         },
         "minimum-stability": {
-            "type": ["string"],
+            "type": "string",
             "description": "The minimum stability the packages must have to be install-able. Possible values are: dev, alpha, beta, RC, stable.",
             "enum": [ "dev", "alpha", "beta", "rc", "RC", "stable" ]
         },


### PR DESCRIPTION
In the JSON schema we have definitions like `"type": ["object", "array"],` or `"type": "string",`.
The key `"minimum-stability"` has a `"type": ["string"],`.
The array definition with `[` and `]` is unnecessary here, because it can only contain a string.