### PR TITLE
Add missing "type": "string", for "bin-compat" config value

### DIFF
--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -208,6 +208,7 @@
                     "description": "The cache max size for the files cache, defaults to \"300MiB\"."
                 },
                 "bin-compat": {
+                    "type": "string",
                     "enum": ["auto", "full"],
                     "description": "The compatibility of the binaries, defaults to \"auto\" (automatically guessed) and can be \"full\" (compatible with both Windows and Unix-based systems)."
                 },


### PR DESCRIPTION
For config.bin-compat the string type is missing.