### PR TITLE
prevent load old version if it's not required

### DIFF
--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -97,6 +97,10 @@
             "type": "boolean",
             "description": "If true, selects all versions of all packages in the repositories defined."
         },
+        "require-best-dependencies": {
+            "type": "boolean",
+            "description": "If true, resolve and add the best dependencies of each required package."
+        },
         "require-dependencies": {
             "type": "boolean",
             "description": "If true, resolve and add all dependencies of each required package."

--- a/src/Console/Command/BuildCommand.php
+++ b/src/Console/Command/BuildCommand.php
@@ -47,6 +47,7 @@ class BuildCommand extends BaseCommand
                 new InputOption('repository-url', null, InputOption::VALUE_OPTIONAL, 'Only update the repository at given url', null),
                 new InputOption('no-html-output', null, InputOption::VALUE_NONE, 'Turn off HTML view'),
                 new InputOption('skip-errors', null, InputOption::VALUE_NONE, 'Skip Download or Archive errors'),
+                new InputOption('best-candidate-strategy', null, InputOption::VALUE_NONE, 'Download only the best candidate version'),
                 new InputOption('stats', null, InputOption::VALUE_NONE, 'Display the download progress bar'),
             ])
             ->setHelp(<<<'EOT'
@@ -113,6 +114,7 @@ EOT
         $packagesFilter = $input->getArgument('packages');
         $repositoryUrl = $input->getOption('repository-url');
         $skipErrors = (bool) $input->getOption('skip-errors');
+        $bestCandidateStrategy = (bool) $input->getOption('best-candidate-strategy');
 
         // load auth.json authentication information and pass it to the io interface
         $io = $this->getIO();
@@ -172,7 +174,7 @@ EOT
         /** @var $application Application */
         $application = $this->getApplication();
         $composer = $application->getComposer(true, $config);
-        $packageSelection = new PackageSelection($output, $outputDir, $config, $skipErrors);
+        $packageSelection = new PackageSelection($output, $outputDir, $config, $skipErrors, $bestCandidateStrategy);
 
         if ($repositoryUrl !== null) {
             $packageSelection->setRepositoryFilter($repositoryUrl);

--- a/src/Console/Command/BuildCommand.php
+++ b/src/Console/Command/BuildCommand.php
@@ -47,7 +47,6 @@ class BuildCommand extends BaseCommand
                 new InputOption('repository-url', null, InputOption::VALUE_OPTIONAL, 'Only update the repository at given url', null),
                 new InputOption('no-html-output', null, InputOption::VALUE_NONE, 'Turn off HTML view'),
                 new InputOption('skip-errors', null, InputOption::VALUE_NONE, 'Skip Download or Archive errors'),
-                new InputOption('best-candidate-strategy', null, InputOption::VALUE_NONE, 'Download only the best candidate version'),
                 new InputOption('stats', null, InputOption::VALUE_NONE, 'Display the download progress bar'),
             ])
             ->setHelp(<<<'EOT'
@@ -114,7 +113,6 @@ EOT
         $packagesFilter = $input->getArgument('packages');
         $repositoryUrl = $input->getOption('repository-url');
         $skipErrors = (bool) $input->getOption('skip-errors');
-        $bestCandidateStrategy = (bool) $input->getOption('best-candidate-strategy');
 
         // load auth.json authentication information and pass it to the io interface
         $io = $this->getIO();
@@ -174,7 +172,7 @@ EOT
         /** @var $application Application */
         $application = $this->getApplication();
         $composer = $application->getComposer(true, $config);
-        $packageSelection = new PackageSelection($output, $outputDir, $config, $skipErrors, $bestCandidateStrategy);
+        $packageSelection = new PackageSelection($output, $outputDir, $config, $skipErrors);
 
         if ($repositoryUrl !== null) {
             $packageSelection->setRepositoryFilter($repositoryUrl);

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -211,7 +211,7 @@ class PackageSelection
                 }
             }
             /** @var Link[] $links */
-            $links = array_merge($links);
+            $links = array_values($links);
         }
 
         // process links if any

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -76,13 +76,13 @@ class PackageSelection
     /**
      * Base Constructor.
      *
-     * @param OutputInterface $output            The output Interface
-     * @param string          $outputDir         The directory where to build
-     * @param array           $config            The parameters from ./satis.json
-     * @param bool            $skipErrors        Escapes Exceptions if true
+     * @param OutputInterface $output                The output Interface
+     * @param string          $outputDir             The directory where to build
+     * @param array           $config                The parameters from ./satis.json
+     * @param bool            $skipErrors            Escapes Exceptions if true
      * @param bool            $bestCandidateStrategy Best candidate strategy
      */
-    public function __construct(OutputInterface $output, $outputDir, $config, $skipErrors,$bestCandidateStrategy)
+    public function __construct(OutputInterface $output, $outputDir, $config, $skipErrors, $bestCandidateStrategy = false)
     {
         $this->output = $output;
         $this->skipErrors = (bool) $skipErrors;


### PR DESCRIPTION
I had a problem when I wanted to have a local copy of other repositories e.g. `"symfony/symonfy: ">=2.7"`. But I also wanted all dependencies like `"doctrine/common"` so I configured `"require-dependencies": true` and everything work fine. 

What was the problem with this? Well satis downloaded all version of everything, it's like I was set "require-all": true. I don't wanted old versions, I only wanted the last version after 2.7, not 2.0, 2.1 ....

So with this pull request I try to improve this feature. You can now download right versions. Also if you set for example `"doctrine/common": ">=2.5"`, it will download `>=2.5` as we expected and not `~2.4` that require symfony, because `>=2.5` match well with `~2.4`.

This work fine for me, but I only have this case of use, please check it.