### PR TITLE
Small layout improvements, optimized SVG usage and 'fixed' panel-titles

### DIFF
--- a/tests/Builder/WebBuilderDumpTest.php
+++ b/tests/Builder/WebBuilderDumpTest.php
@@ -61,7 +61,7 @@ class WebBuilderDumpTest extends \PHPUnit_Framework_TestCase
         $html = $this->root->getChild('build/index.html')->getContent();
 
         $this->assertRegExp('/<title>dummy root package Composer repository<\/title>/', $html);
-        $this->assertRegExp('{<h3 id="[^"]+" class="package-title">\s*<a href="#vendor/name" class="anchor">\s*<svg[^>]*>.+</svg>\s*vendor/name\s*</a>\s*</h3>}si', $html);
+        $this->assertRegExp('{<h3 id="[^"]+" class="panel-title package-title">\s*<a href="#vendor/name" class="anchor">\s*<svg[^>]*>.+</svg>\s*vendor/name\s*</a>\s*</h3>}si', $html);
         $this->assertFalse((bool) preg_match('/<p class="abandoned">/', $html));
     }
 

--- a/views/index.html.twig
+++ b/views/index.html.twig
@@ -108,5 +108,10 @@ $(function () {
     setInterval(function () { momentize(timeElements); }, 5000);
 });
 </script>
+<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+    <symbol id="octicon-link" viewBox="0 0 16 16">
+        <path d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path>
+    </symbol>
+</svg>
 </body>
 </html>

--- a/views/package.html.twig
+++ b/views/package.html.twig
@@ -1,7 +1,7 @@
 <div class="panel {% if package.abandoned %}panel-danger{% else %}panel-info{% endif %}">
 
     <div class="panel-heading">
-        <h3 id="{{ package.highest.name }}" class="package-title">
+        <h3 id="{{ package.highest.name }}" class="panel-title package-title">
             <a href="#{{ package.highest.name }}" class="anchor">
                 <svg class="octicon-link" aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16">
                     <path d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path>
@@ -29,7 +29,7 @@
         {% if package.highest.description %}
         <p class="lead">{{ package.highest.description }}</p>
         {% endif %}
-        
+
         {% if package.highest.keywords %}
         <div class="row">
             <div class="col-xs-2 text-xs-left text-sm-right"><strong>Keywords</strong></div>

--- a/views/package.html.twig
+++ b/views/package.html.twig
@@ -3,8 +3,8 @@
     <div class="panel-heading">
         <h3 id="{{ package.highest.name }}" class="panel-title package-title">
             <a href="#{{ package.highest.name }}" class="anchor">
-                <svg class="octicon-link" aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16">
-                    <path d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path>
+                <svg class="octicon-link" width="16" height="16">
+                    <use xlink:href="#octicon-link"></use>
                 </svg>
                 {{ package.highest.name }}
             </a>


### PR DESCRIPTION
@glensc Mentioned in #343 that the SVG output would be repeated for every package, this is now replaced with SVG symbol/use attributes reducing the actual output.

Also the panel titles are rather large since the introduction of bootstrap, I've added the .panel-title class to resolve this issue and fix some alignment stuff.