### PR TITLE
Explicitly set archive checksum

### DIFF
--- a/src/Builder/ArchiveBuilder.php
+++ b/src/Builder/ArchiveBuilder.php
@@ -131,11 +131,7 @@ class ArchiveBuilder extends Builder
                 $distUrl = sprintf('%s/%s/%s/%s', $endpoint, $this->config['archive']['directory'], $intermediatePath, $archive);
                 $package->setDistType($archiveFormat);
                 $package->setDistUrl($distUrl);
-
-                if ($includeArchiveChecksum) {
-                    $package->setDistSha1Checksum(hash_file('sha1', $path));
-                }
-
+                $package->setDistSha1Checksum($includeArchiveChecksum ? hash_file('sha1', $path) : null);
                 $package->setDistReference($package->getSourceReference());
 
                 if ($renderProgress) {


### PR DESCRIPTION
Artifact repository calculates checksum for all files so it kept in the satis output regardless of the `archive.checksum` option.