### PR TITLE
Allow to specify Docker entrypoint using parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ VOLUME ["/composer", "/build"]
 
 CMD ["--ansi", "-vvv", "build", "/build/satis.json", "/build/output"]
 
-ENTRYPOINT ["/sbin/tini", "--", "/satis/bin/satis"]
+ENTRYPOINT ["/satis/bin/docker-entrypoint.sh"]

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+
+isCommand() {
+  for cmd in \
+    "add" \
+    "build" \
+    "help" \
+    "init" \
+    "list" \
+    "purge"
+  do
+    if [ -z "${cmd#"$1"}" ]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+# check if the first argument passed in looks like a flag
+if [ "$(printf %c "$1")" = '-' ]; then
+  set -- /sbin/tini -- /satis/bin/satis "$@"
+# check if the first argument passed in is satis
+elif [ "$1" = 'satis' ]; then
+  shift
+  set -- /sbin/tini -- /satis/bin/satis "$@"
+# check if the first argument passed in matches a known command
+elif isCommand "$1"; then
+  set -- /sbin/tini -- /satis/bin/satis "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
Using the `composer/satis` image is neat, because thanks to being the entrypoint to the container, you can call the container as you would the binary itself. Of course this is not always what you want and thanks for documenting the way in the readme using custom `--entrypoint`. Unfortunately sometimes you do not control the way the container is being run - typicaly in a docker "cloud", an example of this being the builds in GitLab.

I have dug into this and found out, that a lot of images, which are packaged binaries by default allow to specify a different entrypoint using command line parameters. Great example of this is the [official php images](https://hub.docker.com/_/php/). If you run them without parameters, you get the interactive shell. If you run them with a parameter (and its not an PHP parameter) then this is used as entrypoint.

This is achieved with a custom [entrypoint script](https://github.com/docker-library/php/blob/ec02e1bcf1196ed3f8b74ecc956cf81554e32db8/7.1/docker-php-entrypoint). I have adapted it for the pupose of Satis in this PR and I think it works pretty well. 

---

Here are some situations before and after:

1) without parameters (and no mounted volumes)

before:
```bash
sudo docker run --rm -it composer/satis
File not found: /build/satis.json
```

after:
```bash
sudo docker run --rm -it satis:docker-entrypoint
File not found: /build/satis.json
```

2) Running with a parameter

before:
```bash
sudo docker run --rm -it composer/satis -v
Satis version 1.0.0-dev

...
```

after:
```bash
sudo docker run --rm -it satis:docker-entrypoint -v
Satis version 1.0.0-dev

...
```

3) Running a specific command

before:
```bash
sudo docker run --rm -it composer/satis build
File not found: ./satis.json
```

after:
```bash
$ sudo docker run --rm -it satis:docker-entrypoint build
File not found: ./satis.json
```

4) Specifying a binary

before:
```bash
$ sudo docker run --rm -it composer/satis /bin/sh

  [Symfony\Component\Console\Exception\CommandNotFoundException]  
  Command "/bin/sh" is not defined.                               
```

after:
```bash
sudo docker run --rm -it satis:docker-entrypoint /bin/sh
/satis # 
```

5) Running with parameters incorrectly

before:
```bash
sudo docker run --rm -it composer/satis xxx

  [Symfony\Component\Console\Exception\CommandNotFoundException]  
  Command "xxx" is not defined.                                   
```

after:
```bash
sudo docker run --rm -it satis:docker-entrypoint xxx
/satis/bin/docker-entrypoint: exec: line 17: xxx: not found
```

---

As you can see the usual behavior does not change, only when intented and with the side effect that the unrecognized commands would behave differently. Please tell me if I have missed some case.

You can now run info about the other tools in the package, for example Composer:

```bash
sudo docker run --rm -it satis:docker-entrypoint composer -V
Composer version 1.4.1 2017-03-10 09:29:45
```