### PR TITLE
Add zip extension to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM php:7-alpine
 
 MAINTAINER https://github.com/composer/satis
 
-RUN apk --no-cache add curl git subversion openssh openssl mercurial tini
+RUN apk --no-cache add curl git subversion openssh openssl mercurial tini zlib-dev && \
+    docker-php-ext-install zip
 
 RUN echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \
  && echo "date.timezone=${PHP_TIMEZONE:-UTC}" > "$PHP_INI_DIR/conf.d/date_timezone.ini"


### PR DESCRIPTION
The zip extension is notably missing from the Docker image. If one want's to use an artifact repository, the following exception is produced.

~~~
  [RuntimeException]
  The artifact repository requires PHP's zip extension
~~~