### PR TITLE
add missing libraries required to clone repositories with SSH uri

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7-alpine
 
 MAINTAINER https://github.com/composer/satis
 
-RUN apk --no-cache add curl git subversion mercurial tini zlib-dev
+RUN apk --no-cache add curl git subversion mercurial openssh openssl tini zlib-dev 
 
 RUN docker-php-ext-install zip \
  && echo "memory_limit=-1" > "$PHP_INI_DIR/conf.d/memory-limit.ini" \


### PR DESCRIPTION
Given the changes introduced in the commit https://github.com/composer/satis/commit/f4ce516bb82e7d73fa70695b68f7a5306b3bdd2a the `ssh` command will be missing thus, git actions involving a SSH uris will result on errors: `error: cannot run ssh: No such file or directory `

This pull request only adds those two missing libraries.