### PR TITLE
Adding Support for GitHub as a Satis Repository

### DIFF
--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -69,6 +69,10 @@
                     "description": "Location of the downloads.",
                     "format": "uri"
                 },
+                "providers-prefix": {
+                    "type": "string",
+                    "description": "Prefix for the provider URI template"
+                },
                 "checksum": {
                     "type": "boolean",
                     "description": "If false, will not provide the sha1 checksum for the dist files."

--- a/src/Builder/PackagesBuilder.php
+++ b/src/Builder/PackagesBuilder.php
@@ -26,7 +26,10 @@ class PackagesBuilder extends Builder
     /** @var string packages.json file name. */
     private $filename;
 
-    /** @var string included json filename template */
+	/** @var string prefix for providers URL. */
+	private $providersPrefix = null;
+
+	/** @var string included json filename template */
     private $includeFileName;
 
     private $writtenIncludeJsons = [];
@@ -44,7 +47,8 @@ class PackagesBuilder extends Builder
         parent::__construct($output, $outputDir, $config, $skipErrors);
 
         $this->filename = $this->outputDir . '/packages.json';
-        $this->includeFileName = isset($config['include-filename']) ? $config['include-filename'] : 'include/all$%hash%.json';
+	    $this->includeFileName = isset($config['include-filename']) ? $config['include-filename'] : 'include/all$%hash%.json';
+	    $this->providersPrefix = isset($config['archive']['providers-prefix']) ? trim( $config['archive']['providers-prefix'], '/' ) . '/' : '';
     }
 
     /**
@@ -62,7 +66,7 @@ class PackagesBuilder extends Builder
 
         $repo = ['packages' => []];
         if (isset($this->config['providers']) && $this->config['providers']) {
-            $providersUrl = 'p/%package%$%hash%.json';
+            $providersUrl = $this->providersPrefix . 'p/%package%$%hash%.json';
             if (!empty($this->config['homepage'])) {
                 $repo['providers-url'] = parse_url(rtrim($this->config['homepage'], '/'), PHP_URL_PATH) . '/' . $providersUrl;
             } else {


### PR DESCRIPTION
This simple change allows generating a `packages.json` that will work when hosted in a Git repository.  

This is just a few lines of code that adds a `providers-prefix` property within `.archive` in `satis.json`. I have a working example of this currently located at [github.com/newclarity/wordpress-dependencies](https://github.com/newclarity/wordpress-dependencies/) which only requires this additional setting in `satis.json` _(I am using pseudo-code here):_

```.archive.providers-prefix="master"```

This allows generating a `/p/` URL with `/master/p/` which is what is needed for hosting the Composer repo as a Git repo.

The reason for this is my client did not want to host additional infrastructure and did not want to depend on anything other that GitHub for being able to rebuild and deploy their solution.

**NOTE:** My repo currently depends on [a CircleCI script to change `/p/` to `/master/p/`](https://github.com/newclarity/wordpress-dependencies/blob/master/scripts/compile.sh#L47) so my `satis.json` does not have  `providers-prefix`, but I would really like to see it be possible to run Satis and have it work without have to run scripts to modify its output.

**Also No guarantee that my example Git repo will be there long term _(because it is for a client)_, so please review this sooner than later?**

Thanks in advance for considering.