### PR TITLE
Fix selecting alias instead of package

### DIFF
--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -295,6 +295,12 @@ class PackageSelection
                                     continue;
                                 }
                                 $package = $loader->load($jsonVersion);
+
+                                // skip aliases
+                                if ($package instanceof AliasPackage) {
+                                    $package = $package->getAliasOf();
+                                }
+
                                 $packages[$package->getUniqueName()] = $package;
                             }
                         }

--- a/tests/PackageSelection/PackageSelectionLoadTest.php
+++ b/tests/PackageSelection/PackageSelectionLoadTest.php
@@ -12,6 +12,7 @@
 namespace Composer\Satis\PackageSelection;
 
 use Composer\Package\Package;
+use Composer\Package\AliasPackage;
 use Composer\Satis\Builder\PackagesBuilder;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
@@ -29,12 +30,25 @@ class PackageSelectionLoadTest extends \PHPUnit_Framework_TestCase
     /** @var Package */
     protected $package;
 
+    /** @var Package */
+    protected $devPackage;
+
     /** @var vfsStreamDirectory */
     protected $root;
 
     protected function setUp()
     {
+        static $extra = [
+            "branch-alias" => [
+                "dev-master" => "1.0-dev",
+            ]
+        ];
+
         $this->package = new Package('vendor/name', '1.0.0.0', '1.0');
+        $this->package->setExtra($extra);
+
+        $this->devPackage = new Package('vendor/name', '9999999-dev', 'dev-master');
+        $this->devPackage->setExtra($extra);
 
         $this->root = $this->setFileSystem();
 
@@ -55,7 +69,7 @@ class PackageSelectionLoadTest extends \PHPUnit_Framework_TestCase
             'repositories' => [['type' => 'composer', 'url' => 'http://localhost:54715']],
             'require' => ['vendor/name' => '*'],
         ], false);
-        $packagesBuilder->dump([$this->package]);
+        $packagesBuilder->dump([$this->package, $this->devPackage]);
 
         return $root;
     }
@@ -104,5 +118,22 @@ class PackageSelectionLoadTest extends \PHPUnit_Framework_TestCase
          */
         $this->selection->setPackagesFilter(['othervendor/othername']);
         $this->assertNotEmpty($this->selection->load());
+    }
+
+    public function testAliasNotSelected()
+    {
+        $this->selection->setPackagesFilter(['othervendor/othername']);
+        $packages = $this->selection->load();
+        $this->assertNotEmpty($packages);
+
+        foreach ($packages as $package) {
+            $this->assertNotInstanceOf(AliasPackage::class, $package);
+
+            if ($package->isDev()) {
+                $this->assertSame('dev-master', $package->getPrettyVersion());
+            } else {
+                $this->assertSame('1.0', $package->getPrettyVersion());
+            }
+        }
     }
 }


### PR DESCRIPTION
When building with repository filter, the packages loaded from the previously created `packages.json` contains aliases, and the build produces different package selection.

For example: there are two packages in `satis.json`, the build (without filter) generates these versions:
```
 - package1: dev-master, 0.0.1
 - package2: dev-master, 1.0.0, 0.0.1
```

The package1 has a branch alias, e.g.:
```json
"extra": {
    "branch-alias": {
        "dev-master": "1.0-dev"
    }
},
```

When I run the build for package2, the generated versions are:
```
 - package1: 1.0.x-dev, 0.0.1 <--- Here different version is selected, not dev-master
 - package2: dev-master, 1.0.0, 0.0.1
```

This PR fixes this. I've just added the same lines to `PackageSelection::load()`, that are preventing selecting of aliases in [PackageSelection::select()](https://github.com/composer/satis/blob/44ab184f0962e21af389a6c2e90ef3474c258762/src/PackageSelection/PackageSelection.php#L200). I've also added a test for this case, so I hope nothing breaks :-)