### PR TITLE
[CS] Remove unused imports

### DIFF
--- a/src/Builder/PackagesBuilder.php
+++ b/src/Builder/PackagesBuilder.php
@@ -13,7 +13,6 @@ namespace Composer\Satis\Builder;
 
 use Composer\Json\JsonFile;
 use Composer\Package\Dumper\ArrayDumper;
-use Composer\Util\Filesystem;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -15,7 +15,6 @@ use Composer\Composer;
 use Composer\Factory;
 use Composer\IO\ConsoleIO;
 use Composer\IO\IOInterface;
-use Composer\Satis\Console\Command;
 use Composer\Satis\Satis;
 use Composer\Util\ErrorHandler;
 use Symfony\Component\Console\Application as BaseApplication;

--- a/src/Console/Command/AddCommand.php
+++ b/src/Console/Command/AddCommand.php
@@ -12,7 +12,6 @@
 namespace Composer\Satis\Console\Command;
 
 use Composer\Command\BaseCommand;
-use Composer\Config;
 use Composer\Factory;
 use Composer\IO\NullIO;
 use Composer\Json\JsonFile;


### PR DESCRIPTION
I've removed some unused imports. This save us some lines :put_litter_in_its_place: 

Should we enable it in `php_cs`?