### PR TITLE
added a "_comment" field into satis schema

### DIFF
--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -252,6 +252,10 @@
         "notify-batch": {
             "type": "string",
             "description": "a URL that will be called every time a user installs a package."
+        },
+        "_comment": {
+            "type": ["array", "string"],
+            "description": "A key to store comments in"
         }
     }
 }


### PR DESCRIPTION
support a `"_comment"` field to describe "usefull" things in the statis.json file.

this is kind of a feature parity change, as this is also supported in composer.json

https://github.com/composer/composer/blob/57b3e2451404af0dac0f5fd797fce6789fa2624b/res/composer-schema.json#L513