### PR TITLE
Output the (pretty) version if the progress bar is disabled

### DIFF
--- a/src/Builder/ArchiveBuilder.php
+++ b/src/Builder/ArchiveBuilder.php
@@ -90,7 +90,13 @@ class ArchiveBuilder extends Builder
                     $progressBar->display();
                 }
             } else {
-                $this->output->writeln(sprintf("<info>Dumping '%s'.</info>", $package->getName()));
+                $this->output->writeln(
+                    sprintf(
+                        "<info>Dumping package '%s' in version '%s'.</info>",
+                        $package->getName(),
+                        $package->getPrettyVersion()
+                    )
+                );
             }
 
             try {


### PR DESCRIPTION
I want to see which version of the package the build-command is currently dumping.
So I've added it.