### PR TITLE
Avoid calling the length Twig filter on null

### DIFF
--- a/views/package.html.twig
+++ b/views/package.html.twig
@@ -99,7 +99,7 @@
         </div>
 
         {% set package_dependencies = attribute(dependencies, name) %}
-        {% if package_dependencies|length %}
+        {% if package_dependencies and package_dependencies|length %}
         <div class="row">
             <div class="col-xs-2 text-xs-left text-sm-right"><strong>Required by</strong></div>
             <div class="col-xs-12 col-sm-10">


### PR DESCRIPTION
This fixes the following `Twig_Error_Runtime` error thrown when using PHP 7.2:

```
count(): Parameter must be an array or an object that implements Countable
```