### PR TITLE
added a mouseover title on "last updated" text

### DIFF
--- a/views/index.html.twig
+++ b/views/index.html.twig
@@ -29,7 +29,7 @@
 
             <div class="collapse navbar-collapse in">
                 <p class="navbar-text navbar-right">
-                    <small class="text-muted" title="{{ "now"|date('l, d M Y H:i:s T') }}">
+                    <small class="text-muted" title="{{ "now"|date(constant('\DateTime::COOKIE')) }}">
                         Last updated: <time datetime="{{ "now"|date(constant('\DateTime::RFC3339')) }}">{{ "now"|date('l, d M Y H:i:s T') }}</time>
                     </small>
                 </p>

--- a/views/index.html.twig
+++ b/views/index.html.twig
@@ -29,7 +29,7 @@
 
             <div class="collapse navbar-collapse in">
                 <p class="navbar-text navbar-right">
-                    <small class="text-muted">
+                    <small class="text-muted" title="{{ "now"|date('l, d M Y H:i:s T') }}">
                         Last updated: <time datetime="{{ "now"|date(constant('\DateTime::RFC3339')) }}">{{ "now"|date('l, d M Y H:i:s T') }}</time>
                     </small>
                 </p>


### PR DESCRIPTION
instead of a estimate like "a few minutes ago" or similar one can get a exact timestamp when hovering the text in the website

![grafik](https://user-images.githubusercontent.com/120441/37026760-a964281c-212f-11e8-8b9f-ae9b5b3ef70f.png)
