### PR TITLE
capture blackfire metrics for subprocesses

### DIFF
--- a/.blackfire.yml
+++ b/.blackfire.yml
@@ -1,0 +1,8 @@
+metrics:
+  composer.processes: # metric name
+    label: "composer subprocesses"
+    matching_calls:
+      php:
+        - callee:
+            selector: '=Composer\Util\ProcessExecutor::execute' # aggregate the costs of all Cache::write calls
+            argument: { 1: "^" }  # but create separate nodes by the first argument value

--- a/.blackfire.yml
+++ b/.blackfire.yml
@@ -4,5 +4,5 @@ metrics:
     matching_calls:
       php:
         - callee:
-            selector: '=Composer\Util\ProcessExecutor::execute' # aggregate the costs of all Cache::write calls
+            selector: '=Composer\Util\ProcessExecutor::execute' # aggregate the costs of all ProcessExecutor::execute calls
             argument: { 1: "^" }  # but create separate nodes by the first argument value


### PR DESCRIPTION
after my support question to blackfire with 
https://twitter.com/markusstaab/status/970587335778762752

I got a great answer of the support to utilize [metrics argument capturing](https://blackfire.io/docs/reference-guide/metrics#metrics-capturing-arguments) to get a better understanding of which cli commands are actually the problem (as satis executes 98% of its time within subprocess commands and until now noone could say which are actually the slow ones).

so with this change one can get a better picture of what is going on when running blackfire profiles. 

before this patch
![grafik](https://user-images.githubusercontent.com/120441/37163214-77300798-22f7-11e8-8915-3c49671825d6.png)




with this patch
![grafik](https://user-images.githubusercontent.com/120441/37163309-bbfb6fa2-22f7-11e8-8211-4767ddf7718b.png)
