### PR TITLE
Added "enforce-dependencies" option to enforce constraints on packages

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -123,6 +123,10 @@ If true, selects all versions of all packages in all repositories defined.
 
 If true, resolve and add all dependencies of each required package.
 
+### enforce-dependencies
+
+If true, honor root requirements when resolving dependencies of required packages.
+
 ### require-dev-dependencies
 
 If true, resolve and add all development dependencies of each required package.

--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -137,6 +137,10 @@
             "type": "boolean",
             "description": "If true, resolve and add all dependencies of each required package."
         },
+        "enforce-dependencies": {
+            "type": "boolean",
+            "description": "If true, honor root requirements when resolving dependencies of required packages"
+        },
         "require-dev-dependencies": {
             "type": "boolean",
             "description": "If true, resolve and add all Dev dependencies of each required package."

--- a/src/Console/Command/BuildCommand.php
+++ b/src/Console/Command/BuildCommand.php
@@ -73,6 +73,8 @@ The json config file accepts the following keys:
   required to mirror packagist for example, setting this
   to true will make satis automatically require all of your
   requirements' dependencies.
+- <info>"enforce-dependencies"</info>: if you set to true the option require-dependencies, 
+required dependencies will always honor root requirements.
 - <info>"require-dev-dependencies"</info>: works like require-dependencies
   but requires dev requirements rather than regular ones.
 - <info>"only-dependencies"</info>: only require dependencies - choose this if you want to build

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -669,7 +669,7 @@ class PackageSelection
      *
      * @return Link[]
      */
-    private function selectLinks(Pool $pool, array $links, bool $isRoot, bool $verbose, ConstraintInterface[] $enforced_constraints): array
+    private function selectLinks(Pool $pool, array $links, bool $isRoot, bool $verbose, $enforced_constraints): array
     {
         $depsLinks = $isRoot ? [] : $links;
 

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -690,7 +690,7 @@ class PackageSelection
             } elseif (is_a($link, Link::class)) {
                 $name = $link->getTarget();
                 $link_constraint = $link->getConstraint();
-                if ($this->enforceDependencies && array_key_exists($name, $enforced_constraints) && $link_constraint->getPrettyString() != $enforced_constraints[$name]->getPrettyString()) {
+                if ($this->enforceDependencies && $enforced_constraints && array_key_exists($name, $enforced_constraints) && $link_constraint->getPrettyString() != $enforced_constraints[$name]->getPrettyString()) {
                   $link_constraint = new MultiConstraint([$link_constraint,  $enforced_constraints[$name]], true);
                   $this->output->writeln('Enforce constraints on package '.$name. ': '. $link->getConstraint().' -> '.$link_constraint);
                 }

--- a/tests/PackageSelection/PackageSelectionTest.php
+++ b/tests/PackageSelection/PackageSelectionTest.php
@@ -808,7 +808,7 @@ class PackageSelectionTest extends TestCase
         $reflection = new \ReflectionClass(get_class($builder));
         $method = $reflection->getMethod('selectLinks');
         $method->setAccessible(true);
-        $method->invokeArgs($builder, [$pool, [$rootLink], FALSE, FALSE]);
+        $method->invokeArgs($builder, [$pool, [$rootLink], FALSE, FALSE, null]);
 
         $property = $reflection->getProperty('selected');
         $property->setAccessible(true);


### PR DESCRIPTION
Context/Problem : when using satis with the option "require-dependencies" : "true" and not in "require-all" mode, satis is resolving required dependencies  to deduce which package versions should be downloaded. When you set a constraint on a package in the satis json, unfortunately if a dependency (or a dependency of a dependency) is declaring  broader versions, then satis will fetch those additionnal versions.

Proposed solution : i added a new option named "enforce-dependencies" which allow to restrict dependencies on downloaded packages. 

Remark : the patch is really not perfect, and i'm new to the satis source code, i will be happy to discuss that change.

