### PR TITLE
Archive file name does not conform to the specified archive format

### DIFF
--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -76,6 +76,10 @@
                 "ignore-filters": {
                     "type": "boolean",
                     "description": "Ignore filters when looking for files in the package."
+                },
+                "override-dist-type": {
+                    "type": "boolean",
+                    "description": "If true, archive format will be used to substitute dist type when generating archive file name."
                 }
             }
         },

--- a/src/Builder/ArchiveBuilder.php
+++ b/src/Builder/ArchiveBuilder.php
@@ -43,6 +43,7 @@ class ArchiveBuilder extends Builder
         $endpoint = isset($this->config['archive']['prefix-url']) ? $this->config['archive']['prefix-url'] : $this->config['homepage'];
         $includeArchiveChecksum = isset($this->config['archive']['checksum']) ? (bool) $this->config['archive']['checksum'] : true;
         $ignoreFilters = isset($this->config['archive']['ignore-filters']) ? (bool) $this->config['archive']['ignore-filters'] : false;
+        $overrideDistType = isset($this->config['archive']['override-dist-type']) ? (bool) $this->config['archive']['override-dist-type'] : false;
         $composerConfig = $this->composer->getConfig();
         $factory = new Factory();
         /* @var \Composer\Downloader\DownloadManager $downloadManager */
@@ -99,6 +100,7 @@ class ArchiveBuilder extends Builder
                 }
 
                 $intermediatePath = preg_replace('#[^a-z0-9-_/]#i', '-', $package->getName());
+
                 $packageName = $archiveManager->getPackageFilename($package);
 
                 if ('pear-library' === $package->getType()) {
@@ -109,7 +111,8 @@ class ArchiveBuilder extends Builder
                         realpath($basedir),
                         $intermediatePath,
                         $packageName,
-                        pathinfo($package->getDistUrl(), PATHINFO_EXTENSION))
+                        pathinfo($package->getDistUrl(), PATHINFO_EXTENSION)
+                    )
                     ;
 
                     if (!file_exists($path)) {
@@ -124,6 +127,10 @@ class ArchiveBuilder extends Builder
                     // Set archive format to `file` to tell composer to download it as is
                     $archiveFormat = 'file';
                 } else {
+                    if (true === $overrideDistType) {
+                        $package->setDistType($format);
+                    }
+
                     $path = $archiveManager->archive($package, $format, sprintf('%s/%s', $basedir, $intermediatePath), null, $ignoreFilters);
                     $archiveFormat = $format;
                 }

--- a/tests/Builder/ArchiveBuilderTest.php
+++ b/tests/Builder/ArchiveBuilderTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of composer/satis.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Composer\Satis\Builder;
+
+use Composer\Composer;
+use Composer\IO\NullIO;
+use Composer\Json\JsonFile;
+use Composer\Package\Package;
+use Composer\Package\CompletePackage;
+use Composer\Config as ComposerConfig;
+use Composer\Config\JsonConfigSource;
+use Composer\Downloader\DownloadManager;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * @author Michael Lee <michael.lee@zerustech.com>
+ */
+class ArchiveBuilderTest extends \PHPUnit\Framework\TestCase
+{
+    protected $composer;
+
+    protected $output;
+
+    protected $input;
+
+    protected $outputDir;
+
+    protected $satisConfig;
+
+    public function tearDown()
+    {
+        $root = __DIR__ . '/vfs';
+        $fs = new Filesystem();
+        $fs->remove($root);
+    }
+
+    public function setUp()
+    {
+        $root = __DIR__ . '/vfs';
+        $home = $root . '/home/ubuntu';
+        $target = $home . '/satis.server/dist/monolog/monolog';
+        $fs = new Filesystem();
+        $fs->mkdir($target, 0777);
+        $fs->dumpFile($target . '/monolog-monolog-c41c218e239b50446fd883acb1ecfd4b770caeae-zip-d4a976.tar', 'the package archive.');
+        $fs->dumpFile($target . '/monolog-monolog-c41c218e239b50446fd883acb1ecfd4b770caeae-tar-d4a976.tar', 'the package archive.');
+
+        $composerConfig = new ComposerConfig(true, $home . '/satis.server');
+        $composerConfig->merge([
+            'cache-dir'=> $home . '/.cache/composer',
+            'data-dir'=> $home . '/.local/share/composer',
+            'home'=> $home . '/.config/composer'
+        ]);
+        $composerConfig->setConfigSource(new JsonConfigSource(new JsonFile($home . '/.config/composer/config.json')));
+        $composerConfig->setAuthConfigSource(new JsonConfigSource(new JsonFile($home . '/.config/composer/auth.json')));
+
+        $downloader = $this->getMockBuilder('Composer\Downloader\DownloaderInterface')->disableOriginalConstructor()->getMock();
+        $downloadManager = $this->getMockBuilder('Composer\Downloader\DownloadManager')->disableOriginalConstructor()->getMock();
+        $downloadManager->method('getDownloader')->willReturn($this->returnValue($downloader));
+
+        $this->composer = new Composer();
+        $this->composer->setConfig($composerConfig);
+        $this->composer->setDownloadManager($downloadManager);
+
+        $this->input = $this->getMockBuilder('Symfony\Component\Console\Input\InputInterface')->disableOriginalConstructor()->getMock();
+        $this->input->method('getOption')->with('stats')->willReturn($this->returnValue(false));
+
+        $this->output = new NullOutput();
+
+        $this->outputDir = $home . '/satis.server';
+
+        $this->satisConfig = [
+            "name" => "monolog/monolog",
+            "homepage" => "https://github.com/Seldaek/monolog.git",
+            "repositories" => [
+                [ "type" => "composer", "url" => "https://packagist.org" ]
+            ],
+            "require" => [
+                "monolog/monolog" => "1.13.0"
+            ],
+            "config" => [
+                "secure-http" => false
+            ],
+            "require-dependencies" => false,
+            "require-dev-dependencies" => false,
+            'archive' => [
+                'directory' => 'dist',
+                'format' => 'tar',
+                'prefix-url' => 'http://satis.localhost:4680',
+                'skip-dev' => false
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider getDataForTestDump
+     */
+    public function testDump($customConfig, $packages, $expectedFileName)
+    {
+        $config = array_merge_recursive($this->satisConfig, $customConfig);
+
+        $builder = new ArchiveBuilder($this->output, $this->outputDir, $config, true);
+        $builder->setInput($this->input);
+        $builder->setComposer($this->composer);
+        $builder->dump($packages);
+
+        $this->assertSame($expectedFileName, basename($packages[0]->getDistUrl()));
+    }
+
+    private function getPackages()
+    {
+        $package = new CompletePackage('monolog/monolog', '1.13.0.0', '1.13.0');
+        $package->setId(9);
+        $package->setType('library');
+        $package->setSourceType('git');
+        $package->setSourceUrl('https://github.com/Seldaek/monolog.git');
+        $package->setSourceReference('c41c218e239b50446fd883acb1ecfd4b770caeae');
+        $package->setDistType('zip');
+        $package->setDistUrl('https://api.github.com/repos/Seldaek/monolog/zipball/');
+        $package->setDistReference('c41c218e239b50446fd883acb1ecfd4b770caeae');
+        $package->setReleaseDate(new \DateTime("2015-03-05T01:12:12+00:00"));
+        $package->setExtra(
+            [
+                'branch-alias' => [
+                    'dev-master' => '1.13.x-dev'
+                ]
+            ]
+        );
+        $package->setNotificationUrl('https://packagist.org/downloads/');
+        return [$package];
+    }
+
+    public function getDataForTestDump()
+    {
+        return [
+            [[], $this->getPackages(), 'monolog-monolog-c41c218e239b50446fd883acb1ecfd4b770caeae-zip-d4a976.tar'],
+            [['archive' => ['override-dist-type' => false]], $this->getPackages(), 'monolog-monolog-c41c218e239b50446fd883acb1ecfd4b770caeae-zip-d4a976.tar'],
+            [['archive' => ['override-dist-type' => true]], $this->getPackages(), 'monolog-monolog-c41c218e239b50446fd883acb1ecfd4b770caeae-tar-d4a976.tar']
+        ];
+    }
+}


### PR DESCRIPTION
When the dist type of the remote archive is different with the dist type
specified in satis.json, the remote dist type is used as part of the
file name of the archive generated by satis, take the following scenario
as an example:

```bash
$ cd ~
$ composer create-project composer/satis:dev-master --keep-vcs
$ mkdir satis.server
$ vi satis.server/satis.json
$ # Update satis.json with the following content:
```

```json
{
    "name": "satis/test",
    "homepage": "https://github.com/composer/satis",
    "repositories": [
        { "type": "composer", "url": "https://packagist.org" }
    ],
    "require": {
        "monolog/monolog": "1.13.0"
    },
    "config": {
        "secure-http": false
    },
    "require-dependencies": false,
    "require-dev-dependencies": false,
    "archive": {
        "directory": "dist",
        "format": "tar",
        "prefix-url": "http://satis.localhost:4680",
        "skip-dev": false
    }
}
```

```bash
$ satis/bin/satis satis.server/satis.json satis.server
$ ls satis.server/dist/monolog/monolog
$ # The archive file is as follows:
$ monolog-monolog-c41c218e239b50446fd883acb1ecfd4b770caeae-zip-d4a976.tar
```

> NOTE: The dist type zip of the remote archive is preserved as part of
the archive file name
monolog-monolog-c41c218e239b50446fd883acb1ecfd4b770caeae-zip-d4a976.tar,
this causes a problem when the satis.server is used as an upstream cache
for other satis instances because when a 2nd level ratis server fetches
archive from the upstream one, the archive will be renamed to
monolog-monolog-c41c218e239b50446fd883acb1ecfd4b770caeae-tar-d4a976.tar,
which causes a cache miss every time.

To fix this issue, an option `override-dist-type` has been added to the
`archive` section, when it is set to true, the local dist type takes
precendence over the remote one.

| Question           | Answer
| ------------------ | ------------------
| **issue**          | #478
| **Bug**            | yes
| **New feature**    | no
| **Target version** | `1.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no