### PR TITLE
Do not render artifact URLs for metapackages

### DIFF
--- a/views/package.html.twig
+++ b/views/package.html.twig
@@ -88,7 +88,9 @@
                     {% set branch_alias = ", branch-alias: " ~ branch_alias %}
                 {%- endif -%}
 
-                {%- if version.distType -%}
+                {%- if package.highest.type == 'metapackage' -%}
+                {{ version.prettyVersion }}
+                {%- elseif version.distType -%}
                 <a href="{{ version.distUrl }}" title="dist-reference: {{ version.distReference }}{{ branch_alias }}">{{ version.prettyVersion }}</a>
                 {%- else -%}
                 <a href="{{ version.sourceUrl }}" title="source-reference: {{ version.sourceReference }}{{ branch_alias }}">{{ version.prettyVersion }}</a>


### PR DESCRIPTION
As of #439, this also affects the generated `index.html`. It also have unexpected results for metapackages, like this satis.json:

```json
    "repositories": [
        {"type": "vcs", "url": "./metapackage/"}
    ],
```
Will render in `index.html` like:

```html
<div class="row">
    <div class="col-xs-2 text-xs-left text-sm-right"><strong>Releases</strong></div>
    <div class="col-xs-12 col-sm-10">
        <a href="./metapackage/" title="source-reference: 00d8773dae036abdc7c15a33d0b668d2db2acd51">dev-master</a>, 
        <a href="./metapackage/" title="source-reference: 00d8773dae036abdc7c15a33d0b668d2db2acd51">1.0.0</a>
    </div>
</div>
```

Which will be invalid when accessing over HTTP.

This is handled for `packages.json` in composer/composer#7501.