### PR TITLE
Streamline build

### DIFF
--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -80,6 +80,10 @@
                 "override-dist-type": {
                     "type": "boolean",
                     "description": "If true, archive format will be used to substitute dist type when generating archive file name."
+                },
+                "rearchive": {
+                    "type": "boolean",
+                    "description": "Create new archives for packages with a tar or zip dist, defaults to true"
                 }
             }
         },

--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -88,6 +88,11 @@
             "description": "A set of additional repositories where packages can be found.",
             "additionalProperties": true
         },
+        "repositories-dep": {
+            "type": ["object", "array"],
+            "description": "A set of additional repositories where packages for dependencies can be found.",
+            "additionalProperties": true
+        },
         "minimum-stability": {
             "type": "string",
             "description": "The minimum stability the packages must have to be install-able. Possible values are: dev, alpha, beta, RC, stable.",

--- a/src/Console/Command/BuildCommand.php
+++ b/src/Console/Command/BuildCommand.php
@@ -45,6 +45,7 @@ class BuildCommand extends BaseCommand
                 new InputArgument('output-dir', InputArgument::OPTIONAL, 'Location where to output built files', null),
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Packages that should be built. If not provided, all packages are built.', null),
                 new InputOption('repository-url', null, InputOption::VALUE_OPTIONAL, 'Only update the repository at given url', null),
+                new InputOption('repository-strict', null, InputOption::VALUE_NONE, 'Also apply the repository filter when resolving dependencies'),
                 new InputOption('no-html-output', null, InputOption::VALUE_NONE, 'Turn off HTML view'),
                 new InputOption('skip-errors', null, InputOption::VALUE_NONE, 'Skip Download or Archive errors'),
                 new InputOption('stats', null, InputOption::VALUE_NONE, 'Display the download progress bar'),
@@ -58,6 +59,7 @@ The json config file accepts the following keys:
 
 - <info>"repositories"</info>: defines which repositories are searched
   for packages.
+- <info>"repositories-dep"</info>: define additional repositories for dependencies
 - <info>"output-dir"</info>: where to output the repository files
   if not provided as an argument when calling build.
 - <info>"require-all"</info>: boolean, if true, all packages present
@@ -175,7 +177,7 @@ EOT
         $packageSelection = new PackageSelection($output, $outputDir, $config, $skipErrors);
 
         if (null !== $repositoryUrl) {
-            $packageSelection->setRepositoryFilter($repositoryUrl);
+            $packageSelection->setRepositoryFilter($repositoryUrl, (bool) $this->getOption('repository-strict'));
         } else {
             $packageSelection->setPackagesFilter($packagesFilter);
         }


### PR DESCRIPTION
**These changes enable the use of the resulting composer-repository as the single source for installing one or multiple packages defined by the primary requirements while heavily reducing the required space and time for building.**


### Improve selection of packages


#### Add config option "repositories-dep" with repositories only used for dependencies

Enables the use of (composer-)repositories like packagist.org in combination with _require-all_.
This makes it possible to have everything from the "primary" repositories and all dependencies in one place. No extra tools for automatic rewriting of _require_ needed.


#### Reduce packages included per dependencies to needed versions

Satis used to include all versions of dependencies into the selection.

With this change it will still select all versions of the primary/root packages defined by _require_ or _require-all_, but reduces the selection of dependencies to those versions which would be selected by Composer when installing one of the primary packages (i.e. possible combinations of _prefer-lowest_ and _prefer-stable_).

Since Composer never installs dev-dependencies for dependencies these are also removed from the selection


#### Add command line option "repository-strict" and provide consistent behavior of repository-filter and packages-filter if it is not set

When running build with _packages_ arguments, Satis would reduce the primary requirements to those packages, but still would install all dependencies.
When running build with _repository-url_ option, Satis would reduce the primary requirements to those it can find in this repository and then install those dependencies it can also find in that repository.

I still have to find the reason, why a combination of both is explicitly made impossible, although it might be desired if you know, that you made changes in only a specific subset of the primary requirements.
But for now the rewritten selection provides consistent behavior resulting in all available dependencies present in the result - no matter how they were found.


### Speed up building of archives

#### Add config option "archive"."rearchive"

For dumping an archive Satis used to download and extract packages like Composer would and then create an archive out of the resulting directory.
If _archive.rearchive_ is set to false and a package already provides a dist of type tar or zip, Satis will now just copy that file.
