### PR TITLE
Streamline build II

### DIFF
--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -126,6 +126,13 @@
             "type": "boolean",
             "description": "If false, will include all versions matching a dependency."
         },
+        "strip-hosts": {
+            "type": ["array", "boolean"],
+            "description": "List of domains, IPs, CIDR notations, '/local' (=localnet and other reserved) or '/private' (=private IPs) to be stripped from the output. If set and non-false, local file paths are removed too.",
+            "items": {
+                "type": "string"
+            }
+        },
         "include-filename": {
             "type": "string",
             "description": "Specify filename instead of default include/all${SHA1_HASH}.json"

--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -122,6 +122,10 @@
             "type": "boolean",
             "description": "If true, resolve and add all Dev dependencies of each required package."
         },
+        "require-dependency-filter": {
+            "type": "boolean",
+            "description": "If false, will include all versions matching a dependency."
+        },
         "include-filename": {
             "type": "string",
             "description": "Specify filename instead of default include/all${SHA1_HASH}.json"

--- a/src/Console/Command/BuildCommand.php
+++ b/src/Console/Command/BuildCommand.php
@@ -78,6 +78,8 @@ The json config file accepts the following keys:
   but requires dev requirements rather than regular ones.
 - <info>"config"</info>: all config options from composer, see
   http://getcomposer.org/doc/04-schema.md#config
+- <info>"strip-hosts"</info>: boolean or an array of domains, IPs, CIDR notations, '/local' (=localnet and other reserved)
+  or '/private' (=private IPs) to be stripped from the output. If set and non-false, local file paths are removed too.
 - <info>"output-html"</info>: boolean, controls whether the repository
   has an html page as well or not.
 - <info>"name"</info>: for html output, this defines the name of the
@@ -190,6 +192,8 @@ EOT
             $downloads->setInput($input);
             $downloads->dump($packages);
         }
+
+        $packages = $packageSelection->clean();
 
         if ($packageSelection->hasFilterForPackages() || $packageSelection->hasRepositoryFilter()) {
             // in case of an active filter we need to load the dumped packages.json and merge the

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -55,6 +55,9 @@ class PackageSelection
     /** @var bool required dev-dependencies if true. */
     private $requireDevDependencies;
 
+    /** @var bool Filter dependencies if true. */
+    private $requireDependencyFilter;
+
     /** @var string Minimum stability accepted for Packages in the list. */
     private $minimumStability;
 
@@ -99,6 +102,7 @@ class PackageSelection
         $this->requireAll = isset($config['require-all']) && true === $config['require-all'];
         $this->requireDependencies = isset($config['require-dependencies']) && true === $config['require-dependencies'];
         $this->requireDevDependencies = isset($config['require-dev-dependencies']) && true === $config['require-dev-dependencies'];
+        $this->requireDependencyFilter = (bool) ($config['require-dependency-filter'] ?? true);
 
         if (!$this->requireAll && !isset($config['require'])) {
             $this->output->writeln('No explicit requires defined, enabling require-all');
@@ -423,7 +427,7 @@ class PackageSelection
                 }
             }
 
-            if (!$isRoot && \count($matches) > 1) {
+            if (!$isRoot && $this->requireDependencyFilter && \count($matches) > 1) {
                 // filter matches like Composer's installer
                 \array_walk($matches, function (&$package) {
                     $package = $package->getId();
@@ -535,7 +539,7 @@ class PackageSelection
         if ($this->requireDependencies) {
             $required = $package->getRequires();
         }
-        if ($isRoot && $this->requireDevDependencies) {
+        if (($isRoot || !$this->requireDependencyFilter) && $this->requireDevDependencies) {
             $required = array_merge($required, $package->getDevRequires());
         }
 


### PR DESCRIPTION
### Add config option require-dependency-filter

When set to false, all versions matching a dependency are included.
See discussion here: #488 

### Add config option strip-hosts

When using Satis with sources that are only locally available, that repo carries ambiguous data.

With this option you can define a `List of domains, IPs, CIDR notations, '/local' (=localnet and other reserved) or '/private' (=private IPs) to be stripped from the output. If set and non-false, local file paths are removed too.`