### PR TITLE
docker: use multistage build for docker build cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 !/docs/
 !/res/
 !/src/
+!/vendor/
 !/views/
 !/composer.json
 !/composer.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,8 @@ RUN apk --no-cache add curl git subversion mercurial openssh openssl tini \
  && apk del .build-deps
 
 ENV COMPOSER_HOME /composer
-ENV PATH "/composer/vendor/bin:$PATH"
-ENV COMPOSER_ALLOW_SUPERUSER 1
 
 COPY php-cli.ini /usr/local/etc/php/
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 COPY --from=build /satis /satis/
 
 WORKDIR /satis

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ docker run --rm -it -v /build:/build composer/satis
 Run the image (with Composer cache from host):
 
 ``` sh
-docker run --rm -it -v /build:/build -v $COMPOSER_HOME:/composer composer/satis
+docker run --rm -it -v /build:/build -v "${COMPOSER_HOME:-$HOME/.composer}:/composer" composer/satis
 ```
 
 If you want to run the image without implicitly running Satis, you have to


### PR DESCRIPTION
the change also includes minor Image size also decrease by 3MB due final runtime not having copy of composer:

```
$ docker images
REPOSITORY        TAG       IMAGE ID            CREATED              SIZE
composer/satis    latest    f5f0b17b376b        6 days ago           167MB
composer/satis    pr-498    2f5f8783d827        32 seconds ago       164MB
```