### PR TITLE
render the ui more compact

### DIFF
--- a/views/assets/satis.css
+++ b/views/assets/satis.css
@@ -1,5 +1,8 @@
 body { padding-top: 20px; }
 
+.panel-body { padding: 10px; }
+.panel-heading { padding: 8px 15px; }
+
 .text-xs-left { text-align: left; }
 .text-xs-right { text-align: right; }
 .text-xs-center { text-align: center; }


### PR DESCRIPTION
refs https://github.com/composer/satis/issues/504

- blue boxes with less "white"-space at the top+bottom
- white body-areas of blue boxes with "white"-space at the top+bottom

*BEFORE*

![grafik](https://user-images.githubusercontent.com/120441/46287154-eb10cd00-c581-11e8-90bc-6b032afedc17.png)

*AFTER*

![grafik](https://user-images.githubusercontent.com/120441/46287168-f49a3500-c581-11e8-8dea-0829c196f26e.png)