### PR TITLE
fix an invalid package name, preparing for Composer 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require-dev": {
         "phpunit/phpunit": "^6.4",
         "phpunit/phpunit-mock-objects": "^4.0",
-        "mikey179/vfsStream": "^1.6",
+        "mikey179/vfsstream": "^1.6",
         "friendsofphp/php-cs-fixer": "^2.11"
     },
     "autoload-dev": {


### PR DESCRIPTION
When installing the packages we get the following warning:


> Deprecation warning: require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters. Please use mikey179/vfsstream instead. Make sure you fix this as Composer 2.0 will error.

This small PR fix the issue