### PR TITLE
readme: add example using github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ See the list of [contributors][] who participate(d) in this project.
 - [composer-satis-builder][] - Simple tool for updating the Satis configuration
     (satis.json) "require" key on the basis of the project composer.json.
 
+## Examples
+
+- [eventum/composer] - A simple static set of packages hosted in GitHub Pages
 
 ## License
 
@@ -98,3 +101,4 @@ Satis is licensed under the MIT License - see the [LICENSE][] file for details
 [satis-control-panel]: https://github.com/realshadow/satis-control-panel
 [composer-satis-builder]: https://github.com/AOEpeople/composer-satis-builder
 [LICENSE]: https://github.com/composer/satis/blob/master/LICENSE
+[eventum/composer]: https://github.com/eventum/composer


### PR DESCRIPTION
add examples section.

add eventum/composer as first example:
a) i'm pretty proud of the result, how simple it is and using existing free infrastructure
b) i wish such project existed when i started with ([initial commit in Oct 25, 2014](https://github.com/eventum/composer/commit/3741e6f85c029f5e6e100498d1a695ce504ec4a3))

it includes packages that are difficult to declare (or slow):
- pear packages (vcs type pear is really slow to index)
- projects who do not exist in packagist
  - sphinx/php-sphinxapi
  - php-gettext/php-gettext
  - phplot/phplot
- projects whose packagist integration is broken/incomplete
  - horde/text-flowed
  - horde/util
- forks/backports
  - zendframework/zend-mail
  - defuse/php-encryption