### PR TITLE
Added "minimum-stability-per-package" config option

### DIFF
--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -102,6 +102,16 @@
             "description": "The minimum stability the packages must have to be install-able. Possible values are: dev, alpha, beta, RC, stable.",
             "enum": [ "dev", "alpha", "beta", "rc", "RC", "stable" ]
         },
+        "minimum-stability-per-package": {
+            "type": "object",
+            "description": "This is a hash of package name (keys) and minimum stability (values).",
+            "minProperties": 1,
+            "additionalProperties": {
+                "type": "string",
+                "description": "The minimum stability the package must have to be install-able. Possible values are: dev, alpha, beta, RC, stable. This overrides the \"minimum-stability\" global option for the specified package.",
+                "enum": [ "dev", "alpha", "beta", "rc", "RC", "stable" ]
+            }
+        },
         "abandoned": {
             "type": "object",
             "description": "List of packages marked as abandoned for this repository, the mark can be boolean or a package name/URL pointing to a recommended alternative.",

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -64,6 +64,9 @@ class PackageSelection
     /** @var string Minimum stability accepted for Packages in the list. */
     private $minimumStability;
 
+    /** @var array Minimum stability accepted by Package. */
+    private $minimumStabilityPerPackage;
+
     /** @var array The active package filter to merge. */
     private $packagesFilter = [];
 
@@ -119,6 +122,7 @@ class PackageSelection
         }
 
         $this->minimumStability = $config['minimum-stability'] ?? 'dev';
+        $this->minimumStabilityPerPackage = $config['minimum-stability-per-package'] ?? [];
         $this->abandoned = $config['abandoned'] ?? [];
 
         $this->stripHosts = $this->createStripHostsPatterns($config['strip-hosts'] ?? false);
@@ -186,7 +190,12 @@ class PackageSelection
         $this->output->writeln('<info>Scanning packages</info>');
 
         $repos = $initialRepos = $composer->getRepositoryManager()->getRepositories();
-        $pool = new Pool($this->minimumStability);
+
+        $stabilityFlags = array_map(function ($value) {
+            return BasePackage::$stabilities[$value];
+        }, $this->minimumStabilityPerPackage);
+
+        $pool = new Pool($this->minimumStability, $stabilityFlags);
 
         if ($this->hasRepositoryFilter()) {
             $repos = $this->filterRepositories($repos);

--- a/tests/PackageSelection/PackageSelectionTest.php
+++ b/tests/PackageSelection/PackageSelectionTest.php
@@ -245,9 +245,17 @@ class PackageSelectionTest extends TestCase
                 'name' => 'vendor/project-alpha',
                 'version' => '1.2.3.0',
             ],
+            'alpha-dev' => [
+                'name' => 'vendor/project-alpha',
+                'version' => '1.2.3.1-dev',
+            ],
             'beta' => [
                 'name' => 'vendor/project-beta',
                 'version' => '1.2.3.0',
+            ],
+            'beta-dev' => [
+                'name' => 'vendor/project-beta',
+                'version' => '1.2.3.1-dev',
             ],
             'gamma1' => [
                 'name' => 'vendor/project-gamma',
@@ -344,6 +352,7 @@ class PackageSelectionTest extends TestCase
                 $packages['gamma4'],
             ],
             [
+                'minimum-stability' => 'stable',
                 'repositories' => [
                     $repo['everything'],
                 ],
@@ -361,6 +370,7 @@ class PackageSelectionTest extends TestCase
                 $packages['gamma1'],
             ],
             [
+                'minimum-stability' => 'stable',
                 'repositories' => [
                     $repo['everything'],
                 ],
@@ -378,6 +388,7 @@ class PackageSelectionTest extends TestCase
                 $packages['gamma4'],
             ],
             [
+                'minimum-stability' => 'stable',
                 'repositories' => [
                     $repo['everything'],
                 ],
@@ -396,6 +407,7 @@ class PackageSelectionTest extends TestCase
                 $packages['alpha'],
             ],
             [
+                'minimum-stability' => 'stable',
                 'repositories' => [
                     $repo['everything'],
                 ],
@@ -414,6 +426,7 @@ class PackageSelectionTest extends TestCase
                 $packages['gamma4'],
             ],
             [
+                'minimum-stability' => 'stable',
                 'repositories' => [
                     $repo['everything'],
                 ],
@@ -434,6 +447,7 @@ class PackageSelectionTest extends TestCase
                 $packages['alpha'],
             ],
             [
+                'minimum-stability' => 'stable',
                 'repositories' => [
                     $repo['gamma'],
                     $repo['delta'],
@@ -442,6 +456,27 @@ class PackageSelectionTest extends TestCase
                     $repo['everything'],
                 ],
                 'require-dependencies' => true,
+            ],
+        ];
+
+        $data['Set minimum-stability for a specific package'] = [
+            [
+                $packages['alpha'],
+                $packages['alpha-dev'],
+                $packages['beta']
+            ],
+            [
+                'minimum-stability' => 'stable',
+                'minimum-stability-per-package' => [
+                    'vendor/project-alpha' => 'dev'
+                ],
+                'repositories' => [
+                    $repo['everything'],
+                ],
+                'require' => [
+                    'vendor/project-alpha' => '*',
+                    'vendor/project-beta' => '*'
+                ]
             ],
         ];
 


### PR DESCRIPTION
This solve the issue #442, with a new config option named "minimum-stability-per-package" where we can override the "minimum-stability" option for a set of given packages : 

`"minimum-stability": "stable",
"minimum-stability-per-package": [
    "vendor/package-alpha": "dev"
],`

If it's ok, can I propose the feature for the 1.x branch also ?