### PR TITLE
html: sort keywords

### DIFF
--- a/views/package.html.twig
+++ b/views/package.html.twig
@@ -36,7 +36,7 @@
         {% if package.highest.keywords %}
             <dt class="{{ col1_class }}">Keywords</dt>
             <dd class="{{ col2_class }}">
-                {% for keyword in package.highest.keywords %}
+                {% for keyword in package.highest.keywords|sort %}
                 <span class="badge badge-secondary">{{ keyword }}</span>
                 {% endfor %}
             </dd>


### PR DESCRIPTION
sort `Keywords` list, because it shouldn't matter in what order they came on, output should be consistent.

- doc: https://twig.symfony.com/doc/2.x/filters/sort.html
- example: https://github.com/eventum/composer/commit/cd6d5731f437efb69133cfe6fba9d784eea6d6d4

background: I switched from original `vcs` or `pear` type to `composer` type, and the order changed: https://github.com/eventum/composer/commit/23c24e6338ab748f9277a007eef111519c93b678