### PR TITLE
doc/config: add example how to pull multiple versions

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -20,8 +20,8 @@ title: Config
   "repositories-dep": [],
   "require": {
     "company/package1": "1.2.0",
-    "company/package2": "1.5.2",
-    "company/package3": "dev-master"
+    "company/package2": "^1.5.2",
+    "company/package3": "dev-master|dev-develop"
   },
   "archive": {
     "directory": "dist",


### PR DESCRIPTION
I wanted to list `dev-develop-2.4` and `dev-develop-2.10`, and `dev-develop-*` did not work, so this is good example. will someone 30 minutes in the future!