### PR TITLE
exclude non-source from git export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,5 +15,6 @@
 /.git* export-ignore
 /Dockerfile export-ignore
 /box.json export-ignore
+/docs/ export-ignore
 /tests/ export-ignore
 /webpack.config.js export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,15 @@
 # See core.whitespace @ http://git-scm.com/docs/git-config for whitespace flags.
 *.php   text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4 diff=php
 *.json  text eol=lf whitespace=blank-at-eol,blank-at-eof,space-before-tab,tab-in-indent,tabwidth=4
+
+# Exclude these files from git export.
+# This will effect when package is installed via --prefer-dist
+/*.dist export-ignore
+/.*.dist export-ignore
+/.*.yml export-ignore
+/.dockerignore export-ignore
+/.git* export-ignore
+/Dockerfile export-ignore
+/box.json export-ignore
+/tests/ export-ignore
+/webpack.config.js export-ignore


### PR DESCRIPTION
excludes configs for maintenance tools and tests.

could exclude docs and readme as well, but that is usually debatable.

I personally have an opinion in this matter:
- exclude all that is not needed runtime
- if you need tests, docs, use `--prefer-source` or git checkout the project yourself

to test outcome:
```
git archive --format=tar HEAD | tar tv
```