### PR TITLE
version: back to 1.0.0-dev

### DIFF
--- a/src/Satis.php
+++ b/src/Satis.php
@@ -15,5 +15,5 @@ namespace Composer\Satis;
 
 class Satis
 {
-    const VERSION = '2.0.0-dev';
+    const VERSION = '1.0.0-dev';
 }


### PR DESCRIPTION
I was surprised when I updated my local satis code to dev-master (2845708) it said 2.0.0-dev

looks like that such major bump is very far ahead, so why just stick to 1.x for now.

the change was added in unrelated commit 7297e614900f6616498bc05444f852efb27bccaf and the pull request itself is also rather bogus, no defined scope: https://github.com/composer/satis/pull/538 not even clear was the change intended.