### PR TITLE
WIP: only-dependencies

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -127,6 +127,10 @@ If true, resolve and add all dependencies of each required package.
 
 If true, resolve and add all development dependencies of each required package.
 
+### only-dependencies
+
+If true, will only resolve and add dependencies, not the root projects listed in "require".
+
 ### require-dependency-filter
 
 If false, will include versions matching a dependency.

--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -132,6 +132,10 @@
             "type": "boolean",
             "description": "If true, resolve and add all Dev dependencies of each required package."
         },
+        "only-dependencies": {
+            "type": "boolean",
+            "description": "If true, will not require the root dependencies only their dependencies."
+        },
         "require-dependency-filter": {
             "type": "boolean",
             "description": "If false, will include all versions matching a dependency."

--- a/src/Builder/ArchiveBuilder.php
+++ b/src/Builder/ArchiveBuilder.php
@@ -33,7 +33,16 @@ class ArchiveBuilder extends Builder
 
     public function dump(array $packages): void
     {
-        $helper = new ArchiveBuilderHelper($this->output, $this->config['archive']);
+        $archiveConfig = $this->config['archive'];
+        if ($this->config['only-dependencies']) {
+            $blacklist = (array)($archiveConfig['blacklist'] ?? []);
+            $blacklist += array_keys($this->config['require']);
+
+            $archiveConfig = $this->config['archive'];
+            $archiveConfig['blacklist'] = $blacklist;
+        }
+        $helper = new ArchiveBuilderHelper($this->output, $archiveConfig);
+
         $basedir = $helper->getDirectory($this->outputDir);
         $this->output->writeln(sprintf("<info>Creating local downloads in '%s'</info>", $basedir));
         $endpoint = $this->config['archive']['prefix-url'] ?? $this->config['homepage'];

--- a/src/Builder/ArchiveBuilder.php
+++ b/src/Builder/ArchiveBuilder.php
@@ -33,16 +33,7 @@ class ArchiveBuilder extends Builder
 
     public function dump(array $packages): void
     {
-        $archiveConfig = $this->config['archive'];
-        if ($this->config['only-dependencies']) {
-            $blacklist = (array)($archiveConfig['blacklist'] ?? []);
-            $blacklist += array_keys($this->config['require']);
-
-            $archiveConfig = $this->config['archive'];
-            $archiveConfig['blacklist'] = $blacklist;
-        }
-        $helper = new ArchiveBuilderHelper($this->output, $archiveConfig);
-
+        $helper = new ArchiveBuilderHelper($this->output, $this->config['archive']);
         $basedir = $helper->getDirectory($this->outputDir);
         $this->output->writeln(sprintf("<info>Creating local downloads in '%s'</info>", $basedir));
         $endpoint = $this->config['archive']['prefix-url'] ?? $this->config['homepage'];

--- a/src/Console/Command/BuildCommand.php
+++ b/src/Console/Command/BuildCommand.php
@@ -75,6 +75,8 @@ The json config file accepts the following keys:
   requirements' dependencies.
 - <info>"require-dev-dependencies"</info>: works like require-dependencies
   but requires dev requirements rather than regular ones.
+- <info>"only-dependencies"</info>: only require dependencies - choose this if you want to build
+  a mirror of your project's dependencies without building packages for the main project repositories.
 - <info>"config"</info>: all config options from composer, see
   http://getcomposer.org/doc/04-schema.md#config
 - <info>"strip-hosts"</info>: boolean or an array of domains, IPs, CIDR notations, '/local' (=localnet and other reserved)

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -53,6 +53,9 @@ class PackageSelection
     /** @var bool required dev-dependencies if true. */
     private $requireDevDependencies;
 
+    /** @var bool do not build packages only dependencies */
+    private $onlyDependencies;
+
     /** @var bool Filter dependencies if true. */
     private $requireDependencyFilter;
 
@@ -101,6 +104,7 @@ class PackageSelection
         $this->requireAll = isset($config['require-all']) && true === $config['require-all'];
         $this->requireDependencies = isset($config['require-dependencies']) && true === $config['require-dependencies'];
         $this->requireDevDependencies = isset($config['require-dev-dependencies']) && true === $config['require-dev-dependencies'];
+        $this->onlyDependencies = isset($config['only-dependencies']) && true === $config['only-dependencies'];
         $this->requireDependencyFilter = (bool) ($config['require-dependency-filter'] ?? true);
 
         if (!$this->requireAll && !isset($config['require'])) {
@@ -166,7 +170,9 @@ class PackageSelection
             }
         }
 
-        $this->addRepositories($pool, $repos);
+        if (! $this->onlyDependencies) {
+            $this->addRepositories($pool, $repos);
+        }
 
         // determine the required packages
         $rootLinks = $this->requireAll ? $this->getAllLinks($repos, $this->minimumStability, $verbose) : $this->getFilteredLinks($composer);

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -640,10 +640,12 @@ class PackageSelection
                 $uniqueName = $package->getUniqueName();
                 // add matching package if not yet selected
                 if (!isset($this->selected[$uniqueName])) {
-                    if ($verbose) {
-                        $this->output->writeln('Selected ' . $package->getPrettyName() . ' (' . $package->getPrettyVersion() . ')');
+                    if (false === $isRoot || $this->onlyDependencies === false) {
+                        if ($verbose) {
+                            $this->output->writeln('Selected ' . $package->getPrettyName() . ' (' . $package->getPrettyVersion() . ')');
+                        }
+                        $this->selected[$uniqueName] = $package;
                     }
-                    $this->selected[$uniqueName] = $package;
 
                     $required = $this->getRequired($package, $isRoot);
                     // append non-platform dependencies

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -170,9 +170,7 @@ class PackageSelection
             }
         }
 
-        if (! $this->onlyDependencies) {
-            $this->addRepositories($pool, $repos);
-        }
+        $this->addRepositories($pool, $repos);
 
         // determine the required packages
         $rootLinks = $this->requireAll ? $this->getAllLinks($repos, $this->minimumStability, $verbose) : $this->getFilteredLinks($composer);

--- a/tests/PackageSelection/PackageSelectionTest.php
+++ b/tests/PackageSelection/PackageSelectionTest.php
@@ -376,6 +376,29 @@ class PackageSelectionTest extends TestCase
             ],
         ];
 
+        $data['Require only dependencies'] = [
+            [
+                $packages['alpha'],
+                $packages['epsilon'],
+                $packages['gamma1'],
+                $packages['gamma4'],
+            ],
+            [
+                'minimum-stability' => 'stable',
+                'repositories' => [
+                    $repo['everything'],
+                ],
+                'require' => [
+                    'vendor/project-epsilon' => '*',
+                    'vendor/project-zeta' => '*',
+                    'vendor/project-eta' => '*',
+                ],
+                'require-dependencies' => true,
+                'require-dev-dependencies' => true,
+                'only-dependencies' => true,
+            ],
+        ];
+
         $data['Traverse dependencies but not dev-dependencies'] = [
             [
                 $packages['zeta'],


### PR DESCRIPTION
This adds a config-flag for a usecase that cannot be done differently in an automatic way:

The parameter "only-dependencies" will instruct satis to NOT build the root level packages, only the ones for dependencies.
This is for the following use-case:
Using satis for speeding up continuous integration or other build pipelines behind a slow internet connection. In this case you want satis to automatically detect what packages are used by the software projects - but not have it build those packages as they will clutter up a lot of space and take a lot of time. But you also don't want to keep track of packages or versions manually. Like this you will only have to specify the project's repositories in satis.json and the project names and the new flag, the rest is done automatically.

Example:
```
{
  "name":     "example/projectmirror",
  "homepage": "https://satis.example.org",
  "repositories": [
    { "type": "composer", "url": "https://packagist.org" },
    { "type": "composer", "url": "https://satis.example.org/private-packages" },

    { "type": "vcs", "url": "git@git.example.com:my/project1.git" },
    { "type": "vcs", "url": "git@git.example.com:my/project2.git" }
  ],
  "require": {
    "my/project1":          "*",
    "my/project2": "*"
  },
  "output-dir": "/var/www/satis",
  "require-dependencies"    : true,
  "require-dev-dependencies": true,
  "only-dependencies":        true,
  "providers":                true,
  "archive": {
    "directory": "dist",
    "prefix-url": "https://satis.example.org/projectmirror",
    "skip-dev": false,
    "checksum": false
  }
}
```


WIP because I need to figure out how to write a unit test for this. - Help is of course gladly welcome.