### PR TITLE
Only match best candidates in dependencies, if desired.

### DIFF
--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -136,6 +136,10 @@
             "type": "boolean",
             "description": "If true, will not require the root dependencies only their dependencies."
         },
+        "only-best-candidates": {
+            "type": "boolean",
+            "description": "If true, will only resolve best candidates amongst dependencies."
+        },
         "require-dependency-filter": {
             "type": "boolean",
             "description": "If false, will include all versions matching a dependency."

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -615,7 +615,7 @@ class PackageSelection
                 $matches = [$link];
             } elseif (is_a($link, Link::class)) {
                 $name = $link->getTarget();
-                if ($this->onlyBestCandidates) {
+                if (!$isRoot && $this->onlyBestCandidates) {
                     $selector = new VersionSelector($pool);
                     $matches = [$selector->findBestCandidate($name, $link->getConstraint()->getPrettyString())];
                 }


### PR DESCRIPTION
We want to restrict dependency packages to those that allow the parent packages to be built. This reduces the size of the output from 27MB to 700KB and allows us to provide a "white-listed packages" repository.

This is essentially an updated PR of https://github.com/composer/satis/pull/392 but I haven't encountered the issues the author of that PR encountered, so the code is fairly simple right now.

