### PR TITLE
Docs update for whitelist/blacklist wildcard match

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -93,11 +93,11 @@ absolute-directory
 prefix-url
 : Hostname (and path) to prefix when generating source url for the archive (defaults to **homepage**).
 
-white-list
-: List of whitelisted packages (only matching packages will be output).
+whitelist
+: List of whitelisted packages (only matching packages will be output). A `*` can be used for wildcard matching.
 
-black-list
-: List of blacklisted packages (matching packages will be skipped).
+blacklist
+: List of blacklisted packages (matching packages will be skipped). A `*` can be used for wildcard matching.
 
 checksum
 : Whether or not to generate checksum values.

--- a/docs/using.md
+++ b/docs/using.md
@@ -244,9 +244,9 @@ and Subversion) your packages, add the following to your `satis.json`:
  * `absolute-directory`: optional, a _local_ directory where the dist files are
    dumped instead of `output-dir`/`directory`
  * `whitelist`: optional, if set as a list of package names, satis will only
-   dump the dist files of these packages
+   dump the dist files of these packages (use `*` for wildcard matching)
  * `blacklist`: optional, if set as a list of package names, satis will not
-   dump the dist files of these packages
+   dump the dist files of these packages (use `*` for wildcard matching)
  * `checksum`: optional, `true` by default, when disabled (`false`) satis will
    not provide the sha1 checksum for the dist files
 


### PR DESCRIPTION
Adds the availability of using a `*` for wildcard matching in the whitelist and blacklist to the documentation (wildcard matching was added in #434).