### PR TITLE
Blacklist to prevent undesirable packages from dependencies.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -135,6 +135,10 @@ If true, will only resolve and add dependencies, not the root projects listed in
 
 Useful with require-dependencies, returns a minimal set of dependencies resulting in a constrained package list.
 
+### blacklist
+
+Define a list of packages and versions to suppress in the final packages list. Takes the same format as the `require` section.
+
 ### require-dependency-filter
 
 If false, will include versions matching a dependency.

--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -122,11 +122,11 @@
         },
         "blacklist": {
             "type": "object",
-            "description": "Packages and versions to exclude as blacklisted.",
+            "description": "This is a hash of package name (keys) and version constraints (values) to exclude after selecting packages.",
             "minProperties": 1,
             "additionalProperties": {
                 "type": "string",
-                "description": "A valid version constraint."
+                "description": "A valid version constraint"
             }
         },
         "require-all": {

--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -120,6 +120,15 @@
                 "description": "A valid Package name"
             }
         },
+        "blacklist": {
+            "type": "object",
+            "description": "Packages and versions to exclude as blacklisted.",
+            "minProperties": 1,
+            "additionalProperties": {
+                "type": "string",
+                "description": "A valid version constraint."
+            }
+        },
         "require-all": {
             "type": "boolean",
             "description": "If true, selects all versions of all packages in the repositories defined."

--- a/src/Console/Command/BuildCommand.php
+++ b/src/Console/Command/BuildCommand.php
@@ -91,6 +91,7 @@ The json config file accepts the following keys:
   building the html output.
 - <info>"abandoned"</info>: Packages that are abandoned. As the key use the
   package name, as the value use true or the replacement package.
+- <info>"blacklist"</info>: Packages and versions which should be excluded from the final package list.
 - <info>"notify-batch"</info>: Allows you to specify a URL that will
   be called every time a user installs a package, see
   https://getcomposer.org/doc/05-repositories.md#notify-batch

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -546,11 +546,11 @@ class PackageSelection
     /**
      * Removes selected packages which are blacklisted in configuration.
      *
-     * @param Pool $pool for computing constraint matches.
+     * @param Pool $pool
      *
-     * @return Array of packages that were blacklisted.
+     * @return PackageInterface[]
      */
-    private function pruneBlacklisted($pool, $verbose)
+    private function pruneBlacklisted($pool, $verbose): array
     {
         $blacklisted = [];
         if ($this->hasBlacklist()) {

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -547,6 +547,7 @@ class PackageSelection
      * Removes selected packages which are blacklisted in configuration.
      *
      * @param Pool $pool
+     * @param bool $verbose
      *
      * @return PackageInterface[]
      */


### PR DESCRIPTION
So far "only-best-candidates" is working well for us. We provide this as the lone repository source for applications, and we have a high degree of confidence about the packages being used.

"only-best-candidates" effectively asks composer to choose the best candidate from a list, which is usually the latest within our high level constraints. However, sometimes a deep dependency causes a newer package to be selected (in addition to a desired package) that we don't want to list.

In such cases we might get both `package/bbb:1.1` (checked, security reviewed, and desired) and `package/bbb:1.2` (selected via a deep dependency, but not desired because it hasn't had a security review, and but which is anyway satisfied by `1.1`).

This new `blacklist` feature allows us to effectively define a blacklist policy in the top level of satis.json. To fix the situation described above we can:

```
    "require": {
        "package/aaa": "6.6.6"
    },
    "blacklist": {
        "package/bbb": ">1.1"
    },
    "require-dependencies": true,
    "only-best-candidates": true
```



