### PR TITLE
Improve docs for --only-best-candidates.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -133,7 +133,7 @@ If true, will only resolve and add dependencies, not the root projects listed in
 
 ### only-best-candidates
 
-Useful with require-dependencies, returns a minimal set of dependencies resulting in a constrained package list.
+Returns a minimal set of dependencies needed to satisfy the configuration. The resulting satis repository will contain only one or two versions of each project.
 
 ### blacklist
 

--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -147,7 +147,7 @@
         },
         "only-best-candidates": {
             "type": "boolean",
-            "description": "If true, will only resolve best candidates amongst dependencies."
+            "description": "If true, will attempt to resolve a minimum number of candidates for each dependency."
         },
         "require-dependency-filter": {
             "type": "boolean",


### PR DESCRIPTION
We have discovered in our projects that when we use `--only-best-candidates`, it is quite common to get **multiple** candidates per project, when we really just one one package per project.

To clarify our problem, which i've [put into a test](https://github.com/simesy/satis-1/commit/96330209111738fa8c2ee6be8c02499756de28ec)...

```
A -> B -> D:1
A -> C -> D:1-3
```

In the above example, our strategy is to get `D:1` by setting it as a specific requirement of `B`. However when we get the best candidates for `C` we get `D:3` as the best package. We are left with two packages for `D`, and there is no way for the code to "know" which one we want.

We are using the `blacklist` option to prune some of these out, but in our last release we had a lot doubled up packages that needed to blacklisted. I had a deeper look at the problem and was left unconvinced that there is a way to improve the process (in a way that would be accepted as a patch).

So in the end I have just tweaked the documentation to clarify better what `--only-best-candidates` will do.
