### PR TITLE
Docker: Upgrade based PHP container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN set -eux; \
     --no-suggest \
     --classmap-authoritative
 
-FROM php:7-cli-alpine
+FROM php:7.4-cli-alpine
 
 MAINTAINER https://github.com/composer/satis
 


### PR DESCRIPTION
PHP 7 has been EOL.
Bump based container PHP 7.0 to 7.4.

It works fine in my environment, included tests.