### PR TITLE
Avoid rewriting the same contents in a package file

### DIFF
--- a/src/Builder/PackagesBuilder.php
+++ b/src/Builder/PackagesBuilder.php
@@ -231,6 +231,11 @@ class PackagesBuilder extends Builder
      */
     private function writeToFile(string $path, string $contents): void
     {
+        if (file_exists($path) && sha1_file($path) === sha1($contents)) {
+            // The file already contains the expected contents.
+            return;
+        }
+        
         $dir = dirname($path);
         if (!is_dir($dir)) {
             if (file_exists($dir)) {


### PR DESCRIPTION
Since caching is done via the use of `If-Modified-Since` header, files should not be touched when not modified.
https://github.com/composer/composer/blob/master/UPGRADE-2.0.md#for-composer-repository-implementors