### PR TITLE
Filter packages by type

### DIFF
--- a/docs/using.md
+++ b/docs/using.md
@@ -324,9 +324,14 @@ is set to true.
    [archive](#downloads) instead. See docs on [config schema] for more details.
  * `notify-batch`: optional, specify a URL that will be called every time a
    user installs a package. See [notify-batch].
+ * `include-types`: optional, an array of [composer types]. When provided 
+   only packages with this type will be selected by Satis. 
+ * `exclude-types`: optional, an array of [composer types]. Any packages 
+   with a type in this array will not be selected by Satis. 
 
 [ssh2 context options]: https://secure.php.net/manual/en/wrappers.ssh2.php#refsect1-wrappers.ssh2-options
 [ssl context options]: https://secure.php.net/manual/en/context.ssl.php
 [Twig]: https://twig.sensiolabs.org/
 [config schema]: https://getcomposer.org/doc/04-schema.md#config
 [notify-batch]: https://getcomposer.org/doc/05-repositories.md#notify-batch
+[composer types]: https://getcomposer.org/doc/04-schema.md#type

--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -136,6 +136,22 @@
                 "description": "A valid version constraint"
             }
         },
+        "include-types": {
+            "type": ["array", "null"],
+            "description": "An array of composer types. When an array is provided only packages with this type will be selected by Satis.",
+            "default": null,
+            "items": {
+                "type": "string"
+            }
+        },
+        "exclude-types": {
+            "type": ["array"],
+            "description": "An array of composer types. Any packages with a type in this array will not be selected by Satis.",
+            "default": [],
+            "items": {
+                "type": "string"
+            }
+        },
         "require-all": {
             "type": "boolean",
             "description": "If true, selects all versions of all packages in the repositories defined.",

--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -137,7 +137,7 @@
             }
         },
         "include-types": {
-            "type": ["array", "null"],
+            "type": [ "array", "null" ],
             "description": "An array of composer types. When an array is provided only packages with this type will be selected by Satis.",
             "default": null,
             "items": {
@@ -145,7 +145,7 @@
             }
         },
         "exclude-types": {
-            "type": ["array"],
+            "type": [ "array" ],
             "description": "An array of composer types. Any packages with a type in this array will not be selected by Satis.",
             "default": [],
             "items": {

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -87,11 +87,11 @@ class PackageSelection
 
     /** @var array A list of blacklisted package/constraints. */
     private $blacklist = [];
-    
+
     /** @var array|null A list of package types. If set only packages with one of these types will be selected  */
     private $includeTypes;
-	
-	/** @var array A list of package types that will not be selected */
+
+    /** @var array A list of package types that will not be selected */
     private $excludeTypes = [];
 
     /** @var array|bool Patterns from strip-hosts. */
@@ -127,11 +127,11 @@ class PackageSelection
     {
         return count($this->blacklist) > 0;
     }
-	
-	public function hasTypeFilter(): bool
-	{
-		return $this->includeTypes !== null || count($this->excludeTypes) > 0;
-	}
+
+    public function hasTypeFilter(): bool
+    {
+        return $this->includeTypes !== null || count($this->excludeTypes) > 0;
+    }
 
     public function setPackagesFilter(array $packagesFilter = []): void
     {
@@ -609,28 +609,26 @@ class PackageSelection
         if ($this->hasTypeFilter()) {
             foreach ($this->selected as $selectedKey => $package) {
                 if($this->includeTypes !== null && !in_array($package->getType(), $this->includeTypes)) {
-	                if ($verbose) {
-		                $this->output->writeln(
-		                	'Excluded ' . $package->getPrettyName()
-			                . ' (' . $package->getPrettyVersion() . ') because '
-			                . $package->getType() . ' was not in the array of types to include.'
-		                );
-	                }
-	                $excluded[$selectedKey] = $package;
-	                unset($this->selected[$selectedKey]);
+                    if ($verbose) {
+                        $this->output->writeln(
+                            'Excluded ' . $package->getPrettyName()
+                            . ' (' . $package->getPrettyVersion() . ') because '
+                            . $package->getType() . ' was not in the array of types to include.'
+                        );
+                    }
+                    $excluded[$selectedKey] = $package;
+                    unset($this->selected[$selectedKey]);
                 }
-                elseif (in_array($package->getType(), $this->excludeTypes))
-                {
-	                if ($verbose)
-	                {
-		                $this->output->writeln(
-			                'Excluded ' . $package->getPrettyName()
-			                . ' (' . $package->getPrettyVersion() . ') because '
-			                . $package->getType() . ' was in the array of types to exclude.'
-		                );
-	                }
-	                $excluded[$selectedKey] = $package;
-	                unset($this->selected[$selectedKey]);
+                elseif (in_array($package->getType(), $this->excludeTypes)) {
+                    if ($verbose) {
+                        $this->output->writeln(
+                            'Excluded ' . $package->getPrettyName()
+                            . ' (' . $package->getPrettyVersion() . ') because '
+                            . $package->getType() . ' was in the array of types to exclude.'
+                        );
+                    }
+                    $excluded[$selectedKey] = $package;
+                    unset($this->selected[$selectedKey]);
                 }
             }
         }

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -603,7 +603,7 @@ class PackageSelection
      *
      * @return PackageInterface[]
      */
-    private function pruneByType($verbose): array
+    private function pruneByType(bool $verbose): array
     {
         $excluded = [];
         if ($this->hasTypeFilter()) {
@@ -618,8 +618,7 @@ class PackageSelection
                     }
                     $excluded[$selectedKey] = $package;
                     unset($this->selected[$selectedKey]);
-                }
-                elseif (in_array($package->getType(), $this->excludeTypes)) {
+                } elseif (in_array($package->getType(), $this->excludeTypes)) {
                     if ($verbose) {
                         $this->output->writeln(
                             'Excluded ' . $package->getPrettyName()
@@ -632,6 +631,7 @@ class PackageSelection
                 }
             }
         }
+        
         return $excluded;
     }
 

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -87,6 +87,12 @@ class PackageSelection
 
     /** @var array A list of blacklisted package/constraints. */
     private $blacklist = [];
+    
+    /** @var array|null A list of package types. If set only packages with one of these types will be selected  */
+    private $includeTypes;
+	
+	/** @var array A list of package types that will not be selected */
+    private $excludeTypes = [];
 
     /** @var array|bool Patterns from strip-hosts. */
     private $stripHosts = false;
@@ -121,6 +127,11 @@ class PackageSelection
     {
         return count($this->blacklist) > 0;
     }
+	
+	public function hasTypeFilter(): bool
+	{
+		return $this->includeTypes !== null || count($this->excludeTypes) > 0;
+	}
 
     public function setPackagesFilter(array $packagesFilter = []): void
     {
@@ -207,6 +218,7 @@ class PackageSelection
         $this->setSelectedAsAbandoned();
 
         $this->pruneBlacklisted($pool, $verbose);
+        $this->pruneByType($verbose);
 
         ksort($this->selected, SORT_STRING);
 
@@ -328,6 +340,8 @@ class PackageSelection
         $this->minimumStabilityPerPackage = $config['minimum-stability-per-package'] ?? [];
         $this->abandoned = $config['abandoned'] ?? [];
         $this->blacklist = $config['blacklist'] ?? [];
+        $this->includeTypes = $config['include-types'] ?? null;
+        $this->excludeTypes = $config['exclude-types'] ?? [];
 
         $this->stripHosts = $this->createStripHostsPatterns($config['strip-hosts'] ?? false);
         $this->archiveEndpoint = isset($config['archive']['directory']) ? ($config['archive']['prefix-url'] ?? $config['homepage']) . '/' : null;
@@ -580,6 +594,47 @@ class PackageSelection
             }
         }
         return $blacklisted;
+    }
+
+    /**
+     * Removes packages with types that don't match the configuration
+     *
+     * @param bool $verbose
+     *
+     * @return PackageInterface[]
+     */
+    private function pruneByType($verbose): array
+    {
+        $excluded = [];
+        if ($this->hasTypeFilter()) {
+            foreach ($this->selected as $selectedKey => $package) {
+                if($this->includeTypes !== null && !in_array($package->getType(), $this->includeTypes)) {
+	                if ($verbose) {
+		                $this->output->writeln(
+		                	'Excluded ' . $package->getPrettyName()
+			                . ' (' . $package->getPrettyVersion() . ') because '
+			                . $package->getType() . ' was not in the array of types to include.'
+		                );
+	                }
+	                $excluded[$selectedKey] = $package;
+	                unset($this->selected[$selectedKey]);
+                }
+                elseif (in_array($package->getType(), $this->excludeTypes))
+                {
+	                if ($verbose)
+	                {
+		                $this->output->writeln(
+			                'Excluded ' . $package->getPrettyName()
+			                . ' (' . $package->getPrettyVersion() . ') because '
+			                . $package->getType() . ' was in the array of types to exclude.'
+		                );
+	                }
+	                $excluded[$selectedKey] = $package;
+	                unset($this->selected[$selectedKey]);
+                }
+            }
+        }
+        return $excluded;
     }
 
     /**

--- a/tests/PackageSelection/PackageSelectionTest.php
+++ b/tests/PackageSelection/PackageSelectionTest.php
@@ -554,9 +554,9 @@ class PackageSelectionTest extends TestCase
                 $packages['gamma4'],
             ],
             [
-	            'include-types' => [
-		            'library'
-	            ],
+                'include-types' => [
+                    'library'
+                ],
                 'repositories' => [
                     $repo['everything'],
                 ],
@@ -576,10 +576,10 @@ class PackageSelectionTest extends TestCase
                 $packages['delta'],
             ],
             [
-	            'include-types' => [
-		            'library',
-		            'project'
-	            ],
+                'include-types' => [
+                    'library',
+                    'project'
+                ],
                 'repositories' => [
                     $repo['everything'],
                 ],
@@ -599,9 +599,9 @@ class PackageSelectionTest extends TestCase
                 $packages['eta'],
             ],
             [
-	            'exclude-types' => [
-		            'project'
-	            ],
+                'exclude-types' => [
+                    'project'
+                ],
                 'repositories' => [
                     $repo['everything'],
                 ],
@@ -620,10 +620,10 @@ class PackageSelectionTest extends TestCase
                 $packages['eta'],
             ],
             [
-	            'exclude-types' => [
-		            'project',
-		            'custom-type',
-	            ],
+                'exclude-types' => [
+                    'project',
+                    'custom-type',
+                ],
                 'repositories' => [
                     $repo['everything'],
                 ],

--- a/tests/PackageSelection/PackageSelectionTest.php
+++ b/tests/PackageSelection/PackageSelectionTest.php
@@ -283,30 +283,37 @@ class PackageSelectionTest extends TestCase
             'beta' => [
                 'name' => 'vendor/project-beta',
                 'version' => '1.2.3.0',
+                'type' => 'library',
             ],
             'beta-dev' => [
                 'name' => 'vendor/project-beta',
                 'version' => '1.2.3.1-dev',
+                'type' => 'library',
             ],
             'gamma1' => [
                 'name' => 'vendor/project-gamma',
                 'version' => '1.2.3.0',
+                'type' => 'project',
             ],
             'gamma2' => [
                 'name' => 'vendor/project-gamma',
                 'version' => '2.3.4.0',
+                'type' => 'project',
             ],
             'gamma3' => [
                 'name' => 'vendor/project-gamma',
                 'version' => '3.4.5.0',
+                'type' => 'library',
             ],
             'gamma4' => [
                 'name' => 'vendor/project-gamma',
                 'version' => '4.5.6.0',
+                'type' => 'library',
             ],
             'delta' => [
                 'name' => 'vendor/project-delta',
                 'version' => '1.2.3.0',
+                'type' => 'project',
                 'require' => [
                     'vendor/project-alpha' => '^1',
                     'vendor/project-gamma' => '^1',
@@ -315,6 +322,7 @@ class PackageSelectionTest extends TestCase
             'epsilon' => [
                 'name' => 'vendor/project-epsilon',
                 'version' => '1.2.3.0',
+                'type' => 'custom-type',
                 'require' => [
                     'vendor/project-alpha' => '^1',
                 ],
@@ -325,6 +333,7 @@ class PackageSelectionTest extends TestCase
             'zeta' => [
                 'name' => 'vendor/project-zeta',
                 'version' => '1.2.3.0',
+                'type' => 'another-custom-type',
                 'require' => [
                     'vendor/project-epsilon' => '^1',
                 ],
@@ -332,6 +341,7 @@ class PackageSelectionTest extends TestCase
             'eta' => [
                 'name' => 'vendor/project-eta',
                 'version' => '1.2.3.0',
+                'type' => 'another-custom-type',
                 'require' => [
                     'vendor/project-gamma' => '>=1',
                 ],
@@ -530,6 +540,92 @@ class PackageSelectionTest extends TestCase
                 'require' => [
                     'vendor/project-alpha' => '*',
                     'vendor/project-beta' => '*',
+                ],
+            ],
+        ];
+
+        $data['Filter just libraries'] = [
+            [
+                $packages['alpha'],
+                $packages['alpha-dev'],
+                $packages['beta'],
+                $packages['beta-dev'],
+                $packages['gamma3'],
+                $packages['gamma4'],
+            ],
+            [
+	            'include-types' => [
+		            'library'
+	            ],
+                'repositories' => [
+                    $repo['everything'],
+                ],
+            ],
+        ];
+
+        $data['Filter just libraries and projects'] = [
+            [
+                $packages['alpha'],
+                $packages['alpha-dev'],
+                $packages['beta'],
+                $packages['beta-dev'],
+                $packages['gamma1'],
+                $packages['gamma2'],
+                $packages['gamma3'],
+                $packages['gamma4'],
+                $packages['delta'],
+            ],
+            [
+	            'include-types' => [
+		            'library',
+		            'project'
+	            ],
+                'repositories' => [
+                    $repo['everything'],
+                ],
+            ],
+        ];
+
+        $data['Filter exclude projects'] = [
+            [
+                $packages['alpha'],
+                $packages['alpha-dev'],
+                $packages['beta'],
+                $packages['beta-dev'],
+                $packages['gamma3'],
+                $packages['gamma4'],
+                $packages['epsilon'],
+                $packages['zeta'],
+                $packages['eta'],
+            ],
+            [
+	            'exclude-types' => [
+		            'project'
+	            ],
+                'repositories' => [
+                    $repo['everything'],
+                ],
+            ],
+        ];
+
+        $data['Filter exclude projects, custom'] = [
+            [
+                $packages['alpha'],
+                $packages['alpha-dev'],
+                $packages['beta'],
+                $packages['beta-dev'],
+                $packages['gamma3'],
+                $packages['gamma4'],
+                $packages['zeta'],
+                $packages['eta'],
+            ],
+            [
+	            'exclude-types' => [
+		            'project',
+		            'custom-type',
+	            ],
+                'repositories' => [
+                    $repo['everything'],
                 ],
             ],
         ];


### PR DESCRIPTION
- Implements #609 
- Adds `include-types` and `exclude-types` config options which filter packages by their type, as returned by `$package->getType()`. These remove selected packages that don't match the config in the same way that blacklisted packages are removed.
- Extends `PackageSelectionTest::testSelect` to also cover these options.
- Adds documentation.