### PR TITLE
Stop showing Satis version

### DIFF
--- a/views/index.html.twig
+++ b/views/index.html.twig
@@ -75,7 +75,7 @@
     </div>
 
     <div id="ft">
-        <p class="text-center"><small>This Composer repository is powered by <a href="https://github.com/composer/satis">Satis</a> {{ constant('Composer\\Satis\\Satis::VERSION') }}</small></p>
+        <p class="text-center"><small>This Composer repository is powered by <a href="https://github.com/composer/satis">Satis</a></small></p>
     </div>
 </div>
 


### PR DESCRIPTION
Since Satis isn't really versioned anymore, IMO there isn't any true benefit to showing a version string in the web output.