### PR TITLE
Allow relative paths

### DIFF
--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -3,7 +3,7 @@
     "name": "Repository Configuration",
     "type": "object",
     "additionalProperties": false,
-    "required": [ "name", "homepage" ],
+    "required": [ "name" ],
     "properties": {
         "name": {
             "type": "string",
@@ -15,7 +15,7 @@
         },
         "homepage": {
             "type": "string",
-            "description": "Homepage URL for the Repository.",
+            "description": "Homepage URL for the Repository, required when generating html output.",
             "format": "uri"
         },
         "require": {

--- a/src/Builder/ArchiveBuilder.php
+++ b/src/Builder/ArchiveBuilder.php
@@ -36,7 +36,7 @@ class ArchiveBuilder extends Builder
         $helper = new ArchiveBuilderHelper($this->output, $this->config['archive']);
         $basedir = $helper->getDirectory($this->outputDir);
         $this->output->writeln(sprintf("<info>Creating local downloads in '%s'</info>", $basedir));
-        $endpoint = $this->config['archive']['prefix-url'] ?? $this->config['homepage'];
+        $endpoint = $this->config['archive']['prefix-url'] ?? $this->config['homepage'] ?? '';
         $includeArchiveChecksum = (bool) ($this->config['archive']['checksum'] ?? true);
         $composerConfig = $this->composer->getConfig();
         $factory = new Factory();

--- a/src/Console/Command/PurgeCommand.php
+++ b/src/Console/Command/PurgeCommand.php
@@ -75,7 +75,7 @@ EOT
 
         $prefix = sprintf(
             '%s/%s/',
-            $config['archive']['prefix-url'] ?? $config['homepage'],
+            $config['archive']['prefix-url'] ?? $config['homepage'] ?? '',
             $config['archive']['directory']
         );
 

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -338,7 +338,7 @@ class PackageSelection
         $this->excludeTypes = $config['exclude-types'] ?? [];
 
         $this->stripHosts = $this->createStripHostsPatterns($config['strip-hosts'] ?? false);
-        $this->archiveEndpoint = isset($config['archive']['directory']) ? ($config['archive']['prefix-url'] ?? $config['homepage']) . '/' : null;
+        $this->archiveEndpoint = isset($config['archive']['directory']) ? ($config['archive']['prefix-url'] ?? $config['homepage'] ?? '') . '/' : null;
 
         $this->homepage = $config['homepage'] ?? null;
     }


### PR DESCRIPTION
Why?
To be able to more easily deploy satis across localhost, staging/dev domain and production.



How?
Somehow allowing relative paths as it simplifies config handling a lot:
1. Make `homepage` optional _(as is the case in PR here currently)_ for anything but WebBuilder
    _TODO: If this approach is taken, then `InitCommand` should be relaxed to allow this_
2. Change homepage type to `uri-reference` which allows relative paths + handle duplicate slashes in code when set to `"\"`
    _PRO: This might be cleaner as it then treat the property the same across all code, and it can still be required._
3. ...?

