### PR TITLE
[Build] Add support for SATIS_HOMEPAGE environment variable

### DIFF
--- a/src/Console/Command/BuildCommand.php
+++ b/src/Console/Command/BuildCommand.php
@@ -85,8 +85,8 @@ The json config file accepts the following keys:
   has an html page as well or not.
 - <info>"name"</info>: for html output, this defines the name of the
   repository.
-- <info>"homepage"</info>: for html output, this defines the home URL
-  of the repository (where you will host it).
+- <info>"homepage"</info>: for html output and urls in meta data files, this defines the home URL
+  of the repository (where you will host it). Build command allows this to be overloaded in SATIS_HOMEPAGE environment variable.
 - <info>"twig-template"</info>: Location of twig template to use for
   building the html output.
 - <info>"abandoned"</info>: Packages that are abandoned. As the key use the
@@ -168,6 +168,11 @@ EOT
 
         if (null === $outputDir) {
             throw new \InvalidArgumentException('The output dir must be specified as second argument or be configured inside ' . $input->getArgument('file'));
+        }
+
+        if ($homepage = getenv('SATIS_HOMEPAGE')) {
+            $config['homepage'] = $homepage;
+            $output->writeln(sprintf('<notice>Homepage config used from env SATIS_HOMEPAGE: %s</notice>', $homepage));
         }
 
         /** @var $application Application */

--- a/src/Console/Command/PurgeCommand.php
+++ b/src/Console/Command/PurgeCommand.php
@@ -39,8 +39,9 @@ on given json file (satis.json is used by default) and the
 newest json file in the include directory of the given output-dir.
 
 In your satis.json (or other name you give), you must define
-"archive" argument.
+"archive" argument. You also need to define "homepage"* if you don't use archive "prefix-url".
 
+* "homepage" may be overloaded using SATIS_HOMEPAGE environment variable.
 EOT
             );
     }
@@ -75,7 +76,7 @@ EOT
 
         $prefix = sprintf(
             '%s/%s/',
-            $config['archive']['prefix-url'] ?? $config['homepage'],
+            $config['archive']['prefix-url'] ?? getenv('SATIS_HOMEPAGE') ?? $config['homepage'],
             $config['archive']['directory']
         );
 

--- a/src/Console/Command/PurgeCommand.php
+++ b/src/Console/Command/PurgeCommand.php
@@ -39,9 +39,7 @@ on given json file (satis.json is used by default) and the
 newest json file in the include directory of the given output-dir.
 
 In your satis.json (or other name you give), you must define
-"archive" argument. You also need to define "homepage"* if you don't use archive "prefix-url".
-
-* "homepage" may be overloaded using SATIS_HOMEPAGE environment variable.
+"archive" argument. You also need to define "homepage" argument or "SATIS_HOMEPAGE" environment variable if you don't use archive "prefix-url" argument.
 EOT
             );
     }


### PR DESCRIPTION
If set, will be used over homepage settting in satis.json.
Usefull for staging servers or similar where it's difficult to know url during builds steps for instance before project is deployed.