### PR TITLE
[Composer v2] Support for available-packages / available-package-patterns

### DIFF
--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -195,6 +195,13 @@
             "description": "Specify filename instead of default include/all$%hash%.json",
             "default": "include/all$%hash%.json"
         },
+        "available-package-patterns": {
+            "type": "array",
+            "description": "Composer v2 feature. List of patterns like 'vendor/*' for packages available, recommended with many packages. If not set, 'available-packages' will be set with ALL package names.",
+            "items": {
+                "type": "string"
+            }
+        },
         "output-dir": {
             "type": "string",
             "description": "The directory where the static Repository is built."

--- a/src/Builder/PackagesBuilder.php
+++ b/src/Builder/PackagesBuilder.php
@@ -87,6 +87,12 @@ class PackagesBuilder extends Builder
             $repo['metadata-url'] = $metadataUrl;
         }
 
+        if (!empty($this->config['available-package-patterns'])) {
+            $repo['available-package-patterns'] = $this->config['available-package-patterns'];
+        } else {
+            $repo['available-packages'] = array_keys($packagesByName);
+        }
+
         foreach ($packagesByName as $packageName => $versionPackages) {
             $stableVersions = [];
             $devVersions = [];


### PR DESCRIPTION
Improves performance for Composer v2 against your satis repo, as Composer won't need to do 404 requests for packages you don't have _(in p2/ folder)_. If you have a lot of packages you can configure `available-package-patterns` to at least narrow the amount of 404's Composer would do.

By default all packages will be dumped in `available-package`.
Currently no way to disable this, unless `available-package-patterns` is set to something like `['*']` _(not tested though)_.