### PR TITLE
fix(PurgeCommand): use proper handling for `getenv()`

### DIFF
--- a/src/Console/Command/PurgeCommand.php
+++ b/src/Console/Command/PurgeCommand.php
@@ -80,7 +80,7 @@ EOT
 
         $prefix = sprintf(
             '%s/%s/',
-            $config['archive']['prefix-url'] ?? getenv('SATIS_HOMEPAGE') ?? $config['homepage'],
+            $config['archive']['prefix-url'] ?? getenv('SATIS_HOMEPAGE') ?: $config['homepage'],
             $config['archive']['directory']
         );
 


### PR DESCRIPTION
[getenv()](https://www.php.net/manual/en/function.getenv.php#refsect1-function.getenv-returnvalues) will never return `null` so using null coalesce (`??`) operator is error. As result `$config['homepage']` will be never used as part of prefix.

I my setup satis.json looks like this
```json
{
  "name": "private-repo",
  "homepage": "https://private.repo",
  "repositories": [...],
  "require": { ... },
  "archive": {
    "directory": "dist",
    "format": "zip",
    "skip-dev": true,
    "checksum": true
  }
}
```

So, in my setup satis should use `$config['homepage']` as part of prefix. Variable `SATIS_HOMEPAGE` is undefined and there is no `$config['archive']['prefix-url']` value.

After update  #626 calling `purge` command results to all package files will be removed, because [package prefix will never match $prefix](https://github.com/composer/satis/blob/master/src/Console/Command/PurgeCommand.php#L94).