### PR TITLE
Surface 'type' property in web view

### DIFF
--- a/views/package.html.twig
+++ b/views/package.html.twig
@@ -33,6 +33,11 @@
             <dt class="{{ col1_class }}"></dt>
             <dd class="{{ col2_class }}"></dd>
 
+        {% if package.highest.type %}
+            <dt class="{{ col1_class }}">Type</dt>
+            <dd class="{{ col2_class }}">{{ package.highest.type }}</dd>
+        {% endif %}
+
         {% if package.highest.keywords %}
             <dt class="{{ col1_class }}">Keywords</dt>
             <dd class="{{ col2_class }}">


### PR DESCRIPTION
Right now there is no indication in the web view of the type of a package. This adds in that information.