### PR TITLE
Allow use of Twig debug tools through env variable

### DIFF
--- a/src/Builder/WebBuilder.php
+++ b/src/Builder/WebBuilder.php
@@ -17,6 +17,7 @@ use Composer\Package\CompletePackageInterface;
 use Composer\Package\PackageInterface;
 use Composer\Package\RootPackageInterface;
 use Twig\Environment;
+use Twig\Extension\DebugExtension;
 use Twig\Loader\FilesystemLoader;
 
 class WebBuilder extends Builder
@@ -79,7 +80,11 @@ class WebBuilder extends Builder
 
             $templateDir = $twigTemplate ? pathinfo($twigTemplate, PATHINFO_DIRNAME) : __DIR__ . '/../../views';
             $loader = new FilesystemLoader($templateDir);
-            $this->twig = new Environment($loader);
+            $options = getenv('SATIS_TWIG_DEBUG') ? ['debug' => true] : [];
+            $this->twig = new Environment($loader, $options);
+            if (getenv('SATIS_TWIG_DEBUG')) {
+                $this->twig->addExtension(new DebugExtension());
+            }
         }
 
         return $this->twig;


### PR DESCRIPTION
While making #630, I made some local changes to debug the Twig template of the web view and thought it would be useful to contribute back upstream.

This functionality requires a new environment variable, `SATIS_TWIG_DEBUG`, to be set to opt into. It enables use of Twig's [`dump()`](https://twig.symfony.com/doc/3.x/functions/dump.html) function.