### PR TITLE
PHP Fatal error : Call to a member function getUniqueName() on bool

### DIFF
--- a/src/Console/Command/BuildCommand.php
+++ b/src/Console/Command/BuildCommand.php
@@ -92,6 +92,8 @@ The json config file accepts the following keys:
 - <info>"abandoned"</info>: Packages that are abandoned. As the key use the
   package name, as the value use true or the replacement package.
 - <info>"blacklist"</info>: Packages and versions which should be excluded from the final package list.
+- <info>"only-best-candidates"</info>: Returns a minimal set of dependencies needed to satisfy the configuration. 
+  The resulting satis repository will contain only one or two versions of each project.
 - <info>"notify-batch"</info>: Allows you to specify a URL that will
   be called every time a user installs a package, see
   https://getcomposer.org/doc/05-repositories.md#notify-batch

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -712,7 +712,8 @@ class PackageSelection
                 $name = $link->getTarget();
                 if (!$isRoot && $this->onlyBestCandidates) {
                     $selector = new VersionSelector($pool);
-                    $matches = [$selector->findBestCandidate($name, $link->getConstraint()->getPrettyString())];
+                    $match = $selector->findBestCandidate($name, $link->getConstraint()->getPrettyString());
+                    $matches = $match ? [ $match ] : [];
                 } else {
                     $matches = $pool->whatProvides($name, $link->getConstraint(), true);
                 }


### PR DESCRIPTION
When using _only-best-candidates_ option, I sometimes get this error : 
```
PHP Fatal error:  Uncaught Error: Call to a member function getUniqueName() on bool in /data/dev/satis/src/PackageSelection/PackageSelection.php:746
```
This is because method selector->findBestCandidate() returns  false when no packages matches the selection.

This satis config file fails for example : 
```json
{
    "name": "dgfip/drupal-packagist",
    "homepage": "http://satis.appli.dgfip/dev2",
    "config": {
        "secure-http": false,
        "platform": {
            "php": "7.1"
        }
    },
    "repositories": {
        "composer": {
            "type": "composer",
            "url": "https://packagist.org"
        }
    },
    "require": {
        "justinrainbow/json-schema" : "^1"
    },
    "require-all": false,
    "require-dependencies": true,
    "require-dev-dependencies": true,
    "minimum-stability": "dev",
    "only-best-candidates": true,
    "archive": {
        "directory": "dist",
        "format": "zip",
        "checksum": false,
        "skip-dev": false
    }
}
```


I take this opportunity to add an help item for the _only-best-candidates_ option.
