### PR TITLE
Allow `--repository-url` filter to be used multiple times

### DIFF
--- a/src/Console/Command/BuildCommand.php
+++ b/src/Console/Command/BuildCommand.php
@@ -43,7 +43,7 @@ class BuildCommand extends BaseCommand
                 new InputArgument('file', InputArgument::OPTIONAL, 'Json file to use', './satis.json'),
                 new InputArgument('output-dir', InputArgument::OPTIONAL, 'Location where to output built files', null),
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Packages that should be built. If not provided, all packages are built.', null),
-                new InputOption('repository-url', null, InputOption::VALUE_OPTIONAL, 'Only update the repository at given url', null),
+                new InputOption('repository-url', null, InputOption::VALUE_REQUIRED, 'Only update the repository at given url', null),
                 new InputOption('repository-strict', null, InputOption::VALUE_NONE, 'Also apply the repository filter when resolving dependencies'),
                 new InputOption('no-html-output', null, InputOption::VALUE_NONE, 'Turn off HTML view'),
                 new InputOption('skip-errors', null, InputOption::VALUE_NONE, 'Skip Download or Archive errors'),

--- a/src/Console/Command/BuildCommand.php
+++ b/src/Console/Command/BuildCommand.php
@@ -43,7 +43,7 @@ class BuildCommand extends BaseCommand
                 new InputArgument('file', InputArgument::OPTIONAL, 'Json file to use', './satis.json'),
                 new InputArgument('output-dir', InputArgument::OPTIONAL, 'Location where to output built files', null),
                 new InputArgument('packages', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Packages that should be built. If not provided, all packages are built.', null),
-                new InputOption('repository-url', null, InputOption::VALUE_REQUIRED, 'Only update the repository at given url', null),
+                new InputOption('repository-url', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Only update the repository at given URL(s).', null),
                 new InputOption('repository-strict', null, InputOption::VALUE_NONE, 'Also apply the repository filter when resolving dependencies'),
                 new InputOption('no-html-output', null, InputOption::VALUE_NONE, 'Turn off HTML view'),
                 new InputOption('skip-errors', null, InputOption::VALUE_NONE, 'Skip Download or Archive errors'),
@@ -185,7 +185,7 @@ class BuildCommand extends BaseCommand
         $packageSelection = new PackageSelection($output, $outputDir, $config, $skipErrors);
 
         if (null !== $repositoryUrl) {
-            $packageSelection->setRepositoryFilter($repositoryUrl, (bool) $input->getOption('repository-strict'));
+            $packageSelection->setRepositoriesFilter($repositoryUrl, (bool) $input->getOption('repository-strict'));
         } else {
             $packageSelection->setPackagesFilter($packagesFilter);
         }
@@ -201,7 +201,7 @@ class BuildCommand extends BaseCommand
 
         $packages = $packageSelection->clean();
 
-        if ($packageSelection->hasFilterForPackages() || $packageSelection->hasRepositoryFilter()) {
+        if ($packageSelection->hasFilterForPackages() || $packageSelection->hasRepositoriesFilter()) {
             // in case of an active filter we need to load the dumped packages.json and merge the
             // updated packages in
             $oldPackages = $packageSelection->load();


### PR DESCRIPTION
This change allows the user to filter by more than one repository URL when building their Composer repositories.

My use case is when maintaining subtree splits we fire off one job to update our Satis service for all of the split repositories, unfortunately we hadn't realised that Satis (well actually Symfony Console) just ignores an option specified multiple times when it isn't supposed to be. Our other less important use case is when dealing with GitHub repositories that are configured differently (e.g. `https://...foo`, `https://...foo.git`, or `git@...foo.git`) we tell Satis to run for all 3 URLs assuming one of them is going to be correct.

Example usage:

```sh
bin/satis build
  --repository-url http://example.com/super-sauce.git
  --repository-url https://example.net/foobar.git
  satis.json output/
```

I've also made the option require a value now so `bin/satis build --repository-url satis.json output` is no longer valid.

I've added tests, but I had to run by hacking around with Composers source code as it's currently not possible to override or add a new repository type before the packages get loaded. The sticking point is this code:

https://github.com/composer/composer/blob/c65bd832d6529a542ad5f74d0e49d3353f8632c8/src/Composer/Factory.php#L371-L384