### PR TITLE
Checks if the `$repositoryUrl` is empty array and not just `null`

### DIFF
--- a/src/Console/Command/BuildCommand.php
+++ b/src/Console/Command/BuildCommand.php
@@ -159,7 +159,7 @@ class BuildCommand extends BaseCommand
             $output->writeln(sprintf('<warning>%s: %s</warning>', get_class($e), $e->getMessage()));
         }
 
-        if (null !== $repositoryUrl && count($packagesFilter) > 0) {
+        if ((null !== $repositoryUrl && [] !== $repositoryUrl) && count($packagesFilter) > 0) {
             throw new \InvalidArgumentException('The arguments "package" and "repository-url" can not be used together.');
         }
 


### PR DESCRIPTION
Fixes #668 :
checks if the `$repositoryUrl` is an empty Array since it is now set as `InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY`. 

This corrects the problems when building individual packages for Satis.