### PR TITLE
fixes the package filter

### DIFF
--- a/src/Console/Command/BuildCommand.php
+++ b/src/Console/Command/BuildCommand.php
@@ -184,7 +184,7 @@ class BuildCommand extends BaseCommand
         $composer = $application->getComposer(true, $config);
         $packageSelection = new PackageSelection($output, $outputDir, $config, $skipErrors);
 
-        if (null !== $repositoryUrl) {
+        if (null !== $repositoryUrl && [] !== $repositoryUrl) {
             $packageSelection->setRepositoriesFilter($repositoryUrl, (bool) $input->getOption('repository-strict'));
         } else {
             $packageSelection->setPackagesFilter($packagesFilter);


### PR DESCRIPTION
similar to https://github.com/composer/satis/commit/7128ad33b2682a23e0ddc47f436e66cc74ecf7df
this seems to be a regression from when repositoryUrl was changed to `InputOption::VALUE_IS_ARRAY`
since when the repositoryUrl is not set its an empty array