### PR TITLE
Fix errors for phpstan level 6

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-  level: 5
+  level: 6
   tmpDir: .
   phpVersion: 70428
 

--- a/src/Builder/ArchiveBuilderHelper.php
+++ b/src/Builder/ArchiveBuilderHelper.php
@@ -20,9 +20,15 @@ class ArchiveBuilderHelper
 {
     /** @var OutputInterface The output Interface. */
     private $output;
-    /** @var array The 'archive' part of a configuration file. */
+    /** @var array<string, mixed> The 'archive' part of a configuration file. */
     private $archiveConfig;
 
+    /**
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param array<string, mixed> $archiveConfig
+     * @return void
+     */
     public function __construct(OutputInterface $output, array $archiveConfig)
     {
         $this->output = $output;
@@ -74,6 +80,12 @@ class ArchiveBuilderHelper
         return false;
     }
 
+    /**
+     *
+     * @param array<int, string> $names
+     * @param array<int, string> $list
+     * @return bool
+     */
     protected function isOneOfNamesInList(array $names, array $list): bool
     {
         $patterns = $this->convertListToRegexPatterns($list);
@@ -87,6 +99,12 @@ class ArchiveBuilderHelper
         return false;
     }
 
+    /**
+     *
+     * @param string $name
+     * @param array<int, string> $patterns
+     * @return bool
+     */
     protected function doesNameMatchOneOfPatterns(string $name, array $patterns): bool
     {
         foreach ($patterns as $pattern) {
@@ -98,6 +116,11 @@ class ArchiveBuilderHelper
         return false;
     }
 
+    /**
+     *
+     * @param array<int, string> $list
+     * @return array<int, string>
+     */
     protected function convertListToRegexPatterns(array $list): array
     {
         $patterns = [];

--- a/src/Builder/Builder.php
+++ b/src/Builder/Builder.php
@@ -21,11 +21,19 @@ abstract class Builder implements BuilderInterface
     protected $output;
     /** @var string The directory where to build. */
     protected $outputDir;
-    /** @var array The parameters from ./satis.json. */
+    /** @var array<string, mixed> The parameters from ./satis.json. */
     protected $config;
     /** @var bool Skips Exceptions if true. */
     protected $skipErrors;
 
+    /**
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param string $outputDir
+     * @param array<string, mixed> $config
+     * @param bool $skipErrors
+     * @return void
+     */
     public function __construct(OutputInterface $output, string $outputDir, array $config, bool $skipErrors)
     {
         $this->output = $output;

--- a/src/Builder/BuilderInterface.php
+++ b/src/Builder/BuilderInterface.php
@@ -22,5 +22,5 @@ interface BuilderInterface
      *
      * @param PackageInterface[] $packages List of packages to dump
      */
-    public function dump(array $packages);
+    public function dump(array $packages) : void;
 }

--- a/src/Builder/PackagesBuilder.php
+++ b/src/Builder/PackagesBuilder.php
@@ -26,11 +26,20 @@ class PackagesBuilder extends Builder
     private $filename;
     /** @var string included json filename template */
     private $includeFileName;
-    /** @var array */
+    /** @var array<int, mixed> */
     private $writtenIncludeJsons = [];
     /** @var bool */
     private $minify;
 
+    /**
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param string $outputDir
+     * @param array<string, mixed> $config
+     * @param bool $skipErrors
+     * @param bool $minify
+     * @return void
+     */
     public function __construct(OutputInterface $output, string $outputDir, array $config, bool $skipErrors, bool $minify = false)
     {
         parent::__construct($output, $outputDir, $config, $skipErrors);
@@ -126,6 +135,12 @@ class PackagesBuilder extends Builder
         $this->pruneIncludeDirectories();
     }
 
+    /**
+     *
+     * @param array<string, array> $packages
+     * @param string $replaced
+     * @return array<string, array>
+     */
     private function findReplacements(array $packages, string $replaced): array
     {
         $replacements = [];
@@ -201,6 +216,16 @@ class PackagesBuilder extends Builder
         }
     }
 
+    /**
+     *
+     * @param array<string, array> $packages
+     * @param string $includesUrl
+     * @param string $hashAlgorithm
+     * @return array<string, array>
+     * @throws \RuntimeException
+     * @throws \UnexpectedValueException
+     * @throws \Exception
+     */
     private function dumpPackageIncludeJson(array $packages, string $includesUrl, string $hashAlgorithm = 'sha1'): array
     {
         $filename = str_replace('%hash%', 'prep', $includesUrl);
@@ -273,7 +298,7 @@ class PackagesBuilder extends Builder
     }
 
     /**
-     * @param array $repo Repository information
+     * @param array<string, mixed> $repo Repository information
      */
     private function dumpPackagesJson(array $repo): void
     {

--- a/src/Builder/WebBuilder.php
+++ b/src/Builder/WebBuilder.php
@@ -140,7 +140,7 @@ class WebBuilder extends Builder
      *
      * @param PackageInterface[] $ungroupedPackages List of packages to dump
      *
-     * @return array Grouped list of packages with versions
+     * @return array<string, array> Grouped list of packages with versions
      */
     private function getMappedPackageList(array $ungroupedPackages): array
     {
@@ -166,7 +166,7 @@ class WebBuilder extends Builder
      *
      * @param PackageInterface[] $packages List of packages to dump
      *
-     * @return array List of packages grouped by name
+     * @return array<string, array> List of packages grouped by name
      */
     private function groupPackagesByName(array $packages): array
     {

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -50,7 +50,7 @@ class Application extends BaseApplication
     }
 
     /**
-     * @param array|string|null $config
+     * @param array<string, mixed>|string|null $config
      *  Either a configuration array or a filename to read from, if null it will read from the default filename
      */
     public function getComposer(bool $required = true, $config = null): Composer


### PR DESCRIPTION
Hi, I tried to fix all errors from phpstan on level 6. Not sure if you have a specific wish for the format for iterable types (`array<int,string>` vs `string[]`) but for the rest it should be fine. 

Actually, I think I've found a bug on the implementation of strip-hosts, but please double check that part before merging just in case I misunderstood how it's supposed to work.

It should fix #658 