### PR TITLE
Composer's Package class functions now require hash maps of Links rather than just arrays

### DIFF
--- a/tests/Builder/ArchiveBuilderHelperTest.php
+++ b/tests/Builder/ArchiveBuilderHelperTest.php
@@ -67,7 +67,8 @@ class ArchiveBuilderHelperTest extends TestCase
         $package1 = new Package('vendor/name', '1.0.0.0', '1.0');
         $package2 = new Package('vendor/name', 'dev-master', 'dev-master');
         $package3 = new Package('othervendor/othername', '1.0.0.0', '1.0');
-        $package3->setProvides([new Link('', 'vendor/name', new MatchAllConstraint())]);
+        $link = new Link('', 'vendor/name', new MatchAllConstraint());
+        $package3->setProvides([$link->getTarget() => $link]);
 
         $data = [];
 

--- a/tests/Builder/WebBuilderDumpTest.php
+++ b/tests/Builder/WebBuilderDumpTest.php
@@ -89,7 +89,7 @@ class WebBuilderDumpTest extends TestCase
     public function testDependencies(): void
     {
         $link = new Link('dummytest', 'vendor/name', new MatchAllConstraint());
-        $this->package->setRequires([$link]);
+        $this->package->setRequires([$link->getTarget() => $link]);
         $webBuilder = new WebBuilder(new NullOutput(), vfsStream::url('build'), [], false);
         $webBuilder->setRootPackage($this->rootPackage);
         $webBuilder->dump([$this->package]);

--- a/tests/PackageSelection/PackageSelectionTest.php
+++ b/tests/PackageSelection/PackageSelectionTest.php
@@ -109,8 +109,8 @@ class PackageSelectionTest extends TestCase
         $package = new Package('vendor/name', '1.0.0.0', '1.0');
         $link = new Link('test', 'name', new MatchAllConstraint());
         $devLink = new Link('devTest', 'name', new MatchAllConstraint());
-        $package->setRequires([$link]);
-        $package->setDevRequires([$devLink]);
+        $package->setRequires([$link->getTarget() => $link]);
+        $package->setDevRequires([$devLink->getTarget() => $devLink]);
 
         $data = [];
 
@@ -122,21 +122,21 @@ class PackageSelectionTest extends TestCase
         ];
 
         $data['require true'] = [
-          [$link],
+          [$link->getTarget() => $link],
           $package,
           true,
           false,
         ];
 
         $data['requireDev true'] = [
-          [$devLink],
+          [$devLink->getTarget() => $devLink],
           $package,
           false,
           true,
         ];
 
         $data['both require true'] = [
-          [$link, $devLink],
+          [$link->getTarget() => $link, $devLink->getTarget() => $devLink],
           $package,
           true,
           true,
@@ -1008,11 +1008,11 @@ class PackageSelectionTest extends TestCase
 
         $constraint1 = new Constraint('=', '1.1');
         $link1 = new Link('vendor/a', 'vendor/b', $constraint1, Link::TYPE_REQUIRE);
-        $packageA0->setRequires([$link1]);
+        $packageA0->setRequires([$link1->getTarget() => $link1]);
 
         $constraint2 = new Constraint('<=', '1.1');
         $link2 = new Link('vendor/b', 'vendor/c', $constraint2, Link::TYPE_REQUIRE);
-        $packageB1->setRequires([$link2]);
+        $packageB1->setRequires([$link2->getTarget() => $link2]);
 
         $repository->addPackage($packageA0);
         $repository->addPackage($packageA1);
@@ -1055,7 +1055,7 @@ final class MockPackageSelectionPackageRepository extends PackageRepository impl
     public function __construct(array $config)
     {
         $this->name = $config['package']['name'] ?? $config['package'][0]['name'];
-        $this->url = $config['url'];
+        $this->url = $config['url'] ?? '';
 
         parent::__construct($config);
     }


### PR DESCRIPTION
This should hopefully fix the CI test failures, fixes phpstan level 5 errors