### PR TITLE
Fix a potential PHP 8 type error in PackageSelection class

### DIFF
--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -247,7 +247,7 @@ class PackageSelection
         }
 
         if (isset($rootConfig['providers']) && is_array($rootConfig['providers']) && isset($rootConfig['providers-url'])) {
-            $baseUrl = $this->homepage ? parse_url(rtrim($this->homepage, '/'), PHP_URL_PATH) . '/' : null;
+            $baseUrl = $this->homepage ? parse_url(rtrim($this->homepage, '/'), PHP_URL_PATH) . '/' : '';
             $baseUrlLength = strlen($baseUrl);
 
             foreach ($rootConfig['providers'] as $package => $provider) {


### PR DESCRIPTION
If the homepage is not set in the `PackageSelection` class, then we'll get a `TypeError` in PHP 8 as shown on the image below:


<img width="1269" alt="CleanShot 2022-05-31 at 09 06 45" src="https://user-images.githubusercontent.com/193483/171113016-75e68afc-14b3-4d1e-a1a2-254dc2ad6609.png">

