### PR TITLE
Fixed minify algorithm missing in p2 output

### DIFF
--- a/src/Builder/PackagesBuilder.php
+++ b/src/Builder/PackagesBuilder.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class PackagesBuilder extends Builder
 {
+    public const MINIFY_ALGORITHM_V2 = 'composer/2.0';
+
     /** @var string packages.json file name. */
     private $filename;
     /** @var string included json filename template */
@@ -97,6 +99,12 @@ class PackagesBuilder extends Builder
             $repo['available-packages'] = array_keys($packagesByName);
         }
 
+        $additionalMetaData = [];
+
+        if ($this->minify) {
+            $additionalMetaData['minified'] = self::MINIFY_ALGORITHM_V2;
+        }
+
         foreach ($packagesByName as $packageName => $versionPackages) {
             $stableVersions = [];
             $devVersions = [];
@@ -111,13 +119,17 @@ class PackagesBuilder extends Builder
             // Stable versions
             $this->dumpPackageIncludeJson(
                 [$packageName => $this->minify ? MetadataMinifier::minify($stableVersions) : $stableVersions],
-                str_replace('%package%', $packageName, $metadataUrl)
+                str_replace('%package%', $packageName, $metadataUrl),
+                'sha1',
+                $additionalMetaData
             );
 
             // Dev versions
             $this->dumpPackageIncludeJson(
                 [$packageName => $this->minify ? MetadataMinifier::minify($devVersions) : $devVersions],
-                str_replace('%package%', $packageName.'~dev', $metadataUrl)
+                str_replace('%package%', $packageName.'~dev', $metadataUrl),
+                'sha1',
+                $additionalMetaData
             );
         }
 
@@ -201,7 +213,7 @@ class PackagesBuilder extends Builder
         }
     }
 
-    private function dumpPackageIncludeJson(array $packages, string $includesUrl, string $hashAlgorithm = 'sha1'): array
+    private function dumpPackageIncludeJson(array $packages, string $includesUrl, string $hashAlgorithm = 'sha1', array $additionalMetaData = []): array
     {
         $filename = str_replace('%hash%', 'prep', $includesUrl);
         $path = $tmpPath = $this->outputDir . '/' . ltrim($filename, '/');
@@ -212,7 +224,7 @@ class PackagesBuilder extends Builder
             $options |= JSON_PRETTY_PRINT;
         }
 
-        $contents = $repoJson->encode(['packages' => $packages], $options) . "\n";
+        $contents = $repoJson->encode(array_merge(['packages' => $packages], $additionalMetaData), $options) . "\n";
         $hash = hash($hashAlgorithm, $contents);
 
         if (false !== strpos($includesUrl, '%hash%')) {

--- a/tests/Builder/PackagesBuilderDumpTest.php
+++ b/tests/Builder/PackagesBuilderDumpTest.php
@@ -208,4 +208,36 @@ class PackagesBuilderDumpTest extends TestCase
 
         self::assertEquals(trim(json_encode($expected, $jsonOptions)), trim($content));
     }
+
+    public function testComposer2MinifiedProvider(): void
+    {
+        $expected = [
+            'packages' => [
+                'vendor/name' => [
+                    [
+                        'name' => 'vendor/name',
+                        'version' => '1.0',
+                        'version_normalized' => '1.0.0.0',
+                        'type' => 'library',
+                    ],
+                    [
+                        'version' => '2.0',
+                        'version_normalized' => '2.0.0.0',
+                    ],
+                ],
+            ],
+            'minified' => PackagesBuilder::MINIFY_ALGORITHM_V2,
+        ];
+
+        $packagesBuilder = new PackagesBuilder(new NullOutput(), vfsStream::url('build'), [
+            'repositories' => [['type' => 'composer', 'url' => 'http://localhost:54715']],
+            'require' => ['vendor/name' => '*'],
+        ], false, true);
+        $packagesBuilder->dump(array_merge(self::createPackages(1), self::createPackages(2)));
+        /** @var vfsStreamFile $file */
+        $file = $this->root->getChild('build/p2/vendor/name.json');
+        $content = $file->getContent();
+
+        self::assertEquals($expected, json_decode($content, true));
+    }
 }


### PR DESCRIPTION
There already was a `minify` option for the `PackagesBuilder` but in order for Composer to understand the `p2` format, the output has to contain the `minified` key which specifies the algorithm.

You can see that e.g. here: https://repo.packagist.org/p2/monolog/monolog.json