### PR TITLE
Allow not to dump any includes at all

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -163,6 +163,11 @@ Path to twig template used for generating html output.
 
 If true, output package providers. This will generate a directory per vendor and a json file per package.
 
+### includes
+
+If true, output package includes. This is `true` by default - setting it to `false` allows you to work with Composer v2
+metadata URLs only.
+
 ### pretty-print
 
 Whether or not to use `JSON_PRETTY_PRINT` when generating json output.

--- a/src/Builder/PackagesBuilder.php
+++ b/src/Builder/PackagesBuilder.php
@@ -38,6 +38,7 @@ class PackagesBuilder extends Builder
         $this->filename = $this->outputDir . '/packages.json';
         $this->includeFileName = $config['include-filename'] ?? 'include/all$%hash%.json';
         $this->minify = $minify;
+        $this->config['includes'] = $config['includes'] ?? true;
     }
 
     /**
@@ -79,7 +80,9 @@ class PackagesBuilder extends Builder
                 );
                 $repo['providers'][$packageName] = current($includes);
             }
-        } else {
+        }
+
+        if (isset($this->config['includes']) && $this->config['includes']) {
             $repo['includes'] = $this->dumpPackageIncludeJson($packagesByName, $this->includeFileName);
         }
 


### PR DESCRIPTION
It's basically an old concept and if you only care about Composer v2 metadata URLs, this is just completely superfluous.