### PR TITLE
Handle VCS source URLs in strip-hosts

### DIFF
--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -494,7 +494,12 @@ class PackageSelection
             return false;
         }
 
-        $url = trim(parse_url($url, PHP_URL_HOST), '[]');
+        $sshRegex = '#^[^@:\/]+@([^\/:]+)#ui';
+        if (preg_match($sshRegex, $url, $matches)) {
+            $url = $matches[1];
+        } else {
+            $url = trim(parse_url($url, PHP_URL_HOST), '[]');
+        }
 
         if (false !== filter_var($url, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
             $urltype = 'ipv4';


### PR DESCRIPTION
Providing strip-hosts in the config in combination with VCS repositories leads to an error in matchStripHostsPatterns: 


```
In PackageSelection.php line 501:

  [TypeError]
  trim(): Argument #1 ($string) must be of type string, null given
```

Because the provided URL is in the form of e.g. `git@gitlab.com:company/project`.
PHP's parse_url cannot handle these URLs and returns `null`, which makes `trim` fail.