### PR TITLE
Increase PHPStan rule level to 8

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,7 +5,7 @@ includes:
   - phpstan-baseline.neon
 
 parameters:
-  level: 7
+  level: 8
   tmpDir: .
   phpVersion: 80204
 

--- a/src/Builder/ArchiveBuilder.php
+++ b/src/Builder/ArchiveBuilder.php
@@ -44,14 +44,15 @@ class ArchiveBuilder extends Builder
         $includeArchiveChecksum = (bool) ($this->config['archive']['checksum'] ?? true);
         $composerConfig = $this->composer->getConfig();
         $factory = new Factory();
-        /* @var DownloadManager $downloadManager */
+        /** @var DownloadManager $downloadManager */
         $downloadManager = $this->composer->getDownloadManager();
-        /* @var ArchiveManager $archiveManager */
+        /** @var ArchiveManager $archiveManager */
         $archiveManager = $this->composer->getArchiveManager();
         $archiveManager->setOverwriteFiles(false);
 
         shuffle($packages);
 
+        /** @var ProgressBar|null $progressBar Should only remain `null` if $renderProgress is `false` */
         $progressBar = null;
         $hasStarted = false;
         $verbosity = $this->output->getVerbosity();
@@ -78,7 +79,7 @@ class ArchiveBuilder extends Builder
                 continue;
             }
 
-            if ($renderProgress) {
+            if (!is_null($progressBar)) {
                 $progressBar->setMessage($package->getName(), 'packageName');
                 $progressBar->setMessage($package->getPrettyVersion(), 'packageVersion');
 
@@ -137,14 +138,15 @@ class ArchiveBuilder extends Builder
                 $this->output->writeln(sprintf("<error>Skipping Exception '%s'.</error>", $exception->getMessage()));
             }
 
-            if ($renderProgress) {
+            if (!is_null($progressBar)) {
                 $progressBar->advance();
             }
         }
 
-        if ($renderProgress) {
+        if (!is_null($progressBar)) {
             $progressBar->finish();
-
+        }
+        if ($renderProgress) {
             $this->output->writeln('');
         }
     }

--- a/src/Console/Command/BuildCommand.php
+++ b/src/Console/Command/BuildCommand.php
@@ -196,10 +196,16 @@ class BuildCommand extends BaseCommand
         $application = $this->getApplication();
         if ($application instanceof SatisApplication) {
             $composer = $application->getComposerWithConfig($config);
-            $composerConfig = $composer->getConfig();
         } else {
             $composer = $application->getComposer(true);
-            $composerConfig = $composer->getConfig();
+        }
+
+        if (is_null($composer)) {
+            throw new \Exception('Unable to get Composer instance');
+        }
+
+        $composerConfig = $composer->getConfig();
+        if (!$application instanceof SatisApplication) {
             $composerConfig->merge($config);
             $composer->setConfig($composerConfig);
         }

--- a/src/Console/Command/PurgeCommand.php
+++ b/src/Console/Command/PurgeCommand.php
@@ -92,7 +92,7 @@ class PurgeCommand extends BaseCommand
             if (is_null($package->getDistType())) {
                 continue;
             }
-            $url = $package->getDistUrl();
+            $url = (string) $package->getDistUrl();
             if (substr($url, 0, $length) === $prefix) {
                 $needed[] = substr($url, $length);
             }

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -473,7 +473,7 @@ class PackageSelection
             }
 
             foreach ($sources as $index => $type) {
-                $url = 'source' === $type ? $package->getSourceUrl() : $package->getDistUrl();
+                $url = (string) ('source' === $type ? $package->getSourceUrl() : $package->getDistUrl());
 
                 // skip distURL applied by ArchiveBuilder
                 if ('dist' === $type && null !== $this->archiveEndpoint
@@ -922,7 +922,7 @@ class PackageSelection
                     return false;
                 }
 
-                return in_array($config['url'], $this->repositoriesFilter, true);
+                return in_array($config['url'], $this->repositoriesFilter ?? [], true);
             }
         );
     }

--- a/tests/Builder/ArchiveBuilderTest.php
+++ b/tests/Builder/ArchiveBuilderTest.php
@@ -148,7 +148,7 @@ class ArchiveBuilderTest extends TestCase
         $builder->setComposer($this->composer);
         $builder->dump($packages);
 
-        self::assertSame($expectedFileName, basename($packages[0]->getDistUrl()));
+        self::assertSame($expectedFileName, basename((string) $packages[0]->getDistUrl()));
     }
 
     /**
@@ -206,7 +206,7 @@ class ArchiveBuilderTest extends TestCase
         $builder->setComposer($this->composer);
         $builder->dump($packages);
 
-        self::assertSame($expectedFileName, basename($packages[0]->getDistUrl()));
+        self::assertSame($expectedFileName, basename((string) $packages[0]->getDistUrl()));
     }
 
     private function initArchives(): void


### PR DESCRIPTION
Resolves #660 by increasing [PHPStan rule level](https://phpstan.org/user-guide/rule-levels) to 8 by handling some occurrences of nullable arguments or methods being called on nullable types.