### PR TITLE
Allow generated html output to be indexed by search engines

### DIFF
--- a/docs/using.md
+++ b/docs/using.md
@@ -287,6 +287,8 @@ Example: A `prefix-url` of `https://my-bucket.s3.amazonaws.com` (and
     will not generate the `output-dir`/index.html page.
 -   `twig-template`: optional, a path to a personalized [Twig] template for
     the `output-dir`/index.html page.
+-   `allow-seo-indexing`: optional, `false` by default, when enabled (`true`) satis
+    will allow the generated page to be indexed by search engines.
 
 ### Abandoned packages
 

--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -225,6 +225,11 @@
             "type": "string",
             "description": "Path to a template for the static web page."
         },
+        "allow-seo-indexing": {
+            "type": "boolean",
+            "description": "Allow the generated web view to be indexed by search engines",
+            "default": false
+        },
         "config": {
             "type": "object",
             "description": "Composer options.",

--- a/src/Builder/WebBuilder.php
+++ b/src/Builder/WebBuilder.php
@@ -68,6 +68,7 @@ class WebBuilder extends Builder
             'packages' => $mappedPackages,
             'dependencies' => $this->dependencies,
             'fieldsToToggle' => $this->fieldsToToggle,
+            'blockIndexing' => !isset($this->config['allow-seo-indexing']) || true !== $this->config['allow-seo-indexing'],
         ]);
 
         file_put_contents($this->outputDir . '/index.html', $content);

--- a/src/Console/Command/BuildCommand.php
+++ b/src/Console/Command/BuildCommand.php
@@ -96,6 +96,7 @@ class BuildCommand extends BaseCommand
                   of the repository (where you will host it). Build command allows this to be overloaded in SATIS_HOMEPAGE environment variable.
                 - <info>"twig-template"</info>: Location of twig template to use for
                   building the html output.
+                - <info>"allow-seo-indexing"</info>: Allow the generated html output to be indexed by search engines.
                 - <info>"abandoned"</info>: Packages that are abandoned. As the key use the
                   package name, as the value use true or the replacement package.
                 - <info>"blacklist"</info>: Packages and versions which should be excluded from the final package list.

--- a/views/index.html.twig
+++ b/views/index.html.twig
@@ -5,7 +5,17 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="robots" content="noindex,nofollow" />
+
+    {% if description %}
+        <meta name="description" content="{{ description|striptags|escape("html_attr") }}">
+    {% else %}
+        <meta name="description" content="This Composer repository is powered by Satis">
+    {% endif %}
+    
+    {% if blockIndexing %}
+        <meta name="robots" content="noindex,nofollow">
+    {% endif %}
+
     <link rel="icon" type="image/png" href="{{ source('assets/img/favicon.png')|data_uri(mime="image/png") }}">
 
     <title>{{ name|default('Composer repository') }}</title>


### PR DESCRIPTION
This change allows satis to achieve a 100% Lighthouse score for SEO by adding a new config option to not block search engine indexing, `allow-seo-indexing`. This option is `false` by default, to preserve existing behavior.

We are also adding a meta description to the generated html output. It will try to use the config file's description if set, or a fallback description if not.