### PR TITLE
Add missing symphony resources to phar

### DIFF
--- a/box.json
+++ b/box.json
@@ -11,6 +11,10 @@
             "in": "vendor"
         },
         {
+            "name": "completion.*",
+            "in": "vendor/symfony/console/Resources"
+        },
+        {
             "name": "composer-schema.json",
             "in": "vendor/composer/composer"
         },


### PR DESCRIPTION
Should fix #729 by making sure that the correct resources are being bundled when box compiles the phar file