### PR TITLE
Add 'includes' option to satis schema

### DIFF
--- a/res/satis-schema.json
+++ b/res/satis-schema.json
@@ -195,6 +195,11 @@
             "description": "Specify filename instead of default include/all$%hash%.json",
             "default": "include/all$%hash%.json"
         },
+        "includes": {
+            "type": "boolean",
+            "description": "If true, output package includes. This is `true` by default - setting it to `false` allows you to work with Composer v2 metadata URLs only.",
+            "default": true
+        },
         "available-package-patterns": {
             "type": "array",
             "description": "Composer v2 feature. List of patterns like 'vendor/*' for packages available, recommended with many packages. If not set, 'available-packages' will be set with ALL package names.",


### PR DESCRIPTION
PR #726 added an option to disable output of all Composer v1 metadata with `includes` option. The option has never been added to `satis-schema.json` so an attempt to actually use the option cases error 
```
The property includes is not defined and the definition does not allow additional properties
```
Fixes #751 