### PR TITLE
Fixed Twig 3 deprecation notice for escape character

### DIFF
--- a/views/index.html.twig
+++ b/views/index.html.twig
@@ -11,7 +11,7 @@
     {% else %}
         <meta name="description" content="This Composer repository is powered by Satis">
     {% endif %}
-    
+
     {% if blockIndexing %}
         <meta name="robots" content="noindex,nofollow">
     {% endif %}
@@ -33,8 +33,8 @@
             <a href="{{ url }}">
                 <h1>{{ name|default('Composer repository') }}</h1>
             </a>
-            <span class="badge bg-light text-dark m-1" title="{{ "now"|date(constant('\DateTime::COOKIE')) }}">
-                Last updated: <br class="d-md-none"> <time datetime="{{ "now"|date(constant('\DateTime::RFC3339')) }}">{{ "now"|date('l, d M Y H:i:s T') }}</time>
+            <span class="badge bg-light text-dark m-1" title="{{ "now"|date(constant('\\DateTime::COOKIE')) }}">
+                Last updated: <br class="d-md-none"> <time datetime="{{ "now"|date(constant('\\DateTime::RFC3339')) }}">{{ "now"|date('l, d M Y H:i:s T') }}</time>
             </span>
         </div>
 

--- a/views/package.html.twig
+++ b/views/package.html.twig
@@ -97,7 +97,7 @@
                 {{ version.prettyVersion }}
                 {%- elseif version.distType -%}
                 <a class="badge rounded-pill text-bg-secondary" href="{{ version.distUrl }}" title="dist-reference: {{ version.distReference }}{{ branch_alias }}">{{ version.prettyVersion }}</a>
-                {%- elseif version.sourceUrl matches '#^https?:\/\/#' -%}
+                {%- elseif version.sourceUrl matches '#^https?:\\/\\/#' -%}
                 <a class="badge rounded-pill text-bg-secondary" href="{{ version.sourceUrl }}" title="source-reference: {{ version.sourceReference }}{{ branch_alias }}">{{ version.prettyVersion }}</a>
                 {%- else -%}
                 <span class="badge rounded-pill text-bg-secondary" title="source-reference: {{ version.sourceReference }}{{ branch_alias }}">{{ version.prettyVersion }}</span>


### PR DESCRIPTION
Hello !

I had this small deprecation notice when building the templates : 

```
Deprecation Notice: Since twig/twig 3.12: Character "D" should not be escaped; the "\" character is ignored in Twig 3 but will not be in Twig 4. Please remove the extra "\" character at position 2 in "index.html.twig" at line 36. in /Users/tchapuis/PhpstormProjects/open-source/satisfy/vendor/symfony/deprecation-contracts/function.php:25
```

Based on latest [Twig documentation](https://twig.symfony.com/doc/3.x/templates.html#escaping), `\` characters should escaped with another `\`