### PR TITLE
fix: merge "$config" when composer is already defined

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -86,6 +86,12 @@ class Application extends ComposerApplication
                 }
                 throw $e;
             }
+        } else {
+            if (!is_array($config)) {
+                throw new \InvalidArgumentException('"$config" parameter must be an array');
+            }
+
+            $this->composer->getConfig()->merge($config);
         }
 
         return $this->composer;


### PR DESCRIPTION
Allow the use of "config" key in Satis configuration file.

fix #878