### PR TITLE
Various PHPStan fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "tmp.Xjy0jDX5Qw",
+    "name": "satis",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,11 +16,6 @@ parameters:
 			path: src/PackageSelection/PackageSelection.php
 
 		-
-			message: "#^AnonymousClass413ff361b2bd143aba48f1b9c433653f\\:\\:__construct\\(\\) does not call parent constructor from Composer\\\\Package\\\\Archiver\\\\ArchiveManager\\.$#"
-			count: 1
-			path: tests/Builder/ArchiveBuilderTest.php
-
-		-
 			message: "#^Offset 'url' on array\\{package\\: array\\} on left side of \\?\\? does not exist\\.$#"
 			count: 1
 			path: tests/PackageSelection/PackageSelectionTest.php

--- a/tests/Builder/ArchiveBuilderTest.php
+++ b/tests/Builder/ArchiveBuilderTest.php
@@ -20,6 +20,7 @@ use Composer\Downloader\DownloadManager;
 use Composer\Json\JsonFile;
 use Composer\Package\Archiver\ArchiveManager;
 use Composer\Package\CompletePackage;
+use Composer\Util\Loop;
 use Composer\Package\CompletePackageInterface;
 use Composer\Package\PackageInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -81,9 +82,11 @@ class ArchiveBuilderTest extends TestCase
             }
         );
 
-        $archiveManager = new class extends ArchiveManager {
-            public function __construct()
+        $loop = $this->getMockBuilder(Loop::class)->disableOriginalConstructor()->getMock();
+        $archiveManager = new class($downloadManager, $loop) extends ArchiveManager {
+            public function __construct(DownloadManager $downloadManager, Loop $loop)
             {
+                parent::__construct($downloadManager, $loop);
             }
 
             public function archive(CompletePackageInterface $package, string $format, string $targetDir, ?string $fileName = null, bool $ignoreFilters = false): string


### PR DESCRIPTION
This pull request makes the following small fixes:

1. Fixes the `ArchiveBuilderTest.php` test because the anonymous class extending `ArchiveManager` was not calling the parent constructor.
2. Removes a baseline from `phpstan-baseline.neon` that hasn't been needed in a while and was breaking expectations. Not sure if the baseline was ever actually being applied because of how anonymous class names are generated.
3. Updates the package name in `package-lock.json`, it probably got clobbered during a dependency upgrade.

These changes should allow the `phpstan` action to succeed.