### PR TITLE
Fix blacklist pruning crash with provider-based composer repositories

### DIFF
--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Composer\Satis\PackageSelection;
 
 use Composer\Composer;
+use Composer\DependencyResolver\Pool;
 use Composer\Json\JsonFile;
 use Composer\Package\AliasPackage;
 use Composer\Package\BasePackage;
@@ -260,7 +261,7 @@ class PackageSelection
 
         $this->setSelectedAsAbandoned();
 
-        $this->pruneBlacklisted($repositorySet, $verbose);
+        $this->pruneBlacklisted($verbose);
         $this->pruneByType($verbose);
 
         ksort($this->selected, SORT_STRING);
@@ -630,12 +631,15 @@ class PackageSelection
      *
      * @return PackageInterface[]
      */
-    private function pruneBlacklisted(RepositorySet $repositorySet, bool $verbose): array
+    private function pruneBlacklisted(bool $verbose): array
     {
         $blacklisted = [];
         if ($this->hasBlacklist()) {
             $parser = new VersionParser();
-            $pool = $repositorySet->createPoolWithAllPackages();
+            // Pool::match() only inspects the candidate package itself, so an
+            // empty pool suffices; loading all packages would fail on composer
+            // repositories using providers (which can not list their packages)
+            $pool = new Pool();
             /** @var BasePackage $package */
             foreach ($this->selected as $selectedKey => $package) {
                 foreach ($this->blacklist as $blacklistName => $blacklistConstraint) {

--- a/tests/PackageSelection/PackageSelectionTest.php
+++ b/tests/PackageSelection/PackageSelectionTest.php
@@ -237,6 +237,10 @@ class PackageSelectionTest extends TestCase
         $package1 = new Package('vendor/name', '1.1.0.0', '1.1');
         $package2 = new Package('vendor/name', '1.2.0.0', '1.2');
         $packageOther = new Package('vendor/other', '1.0.0.0', '1.0');
+        $packageReplacing = new Package('vendor/replacer', '1.0.0.0', '1.0');
+        $packageReplacing->setReplaces([
+            'vendor/replaced' => new Link('vendor/replacer', 'vendor/replaced', new Constraint('==', '1.0.0.0'), Link::TYPE_REPLACE, '1.0'),
+        ]);
 
         $data = [];
         $selected = [$package0, $package1, $package2, $packageOther];
@@ -259,6 +263,12 @@ class PackageSelectionTest extends TestCase
             ['vendor/name' => '>1.1'],
         ];
 
+        $data['Blacklist Replaced Package'] = [
+            [$packageOther],
+            [$packageReplacing, $packageOther],
+            ['vendor/replaced' => '*'],
+        ];
+
         return $data;
     }
 
@@ -270,7 +280,6 @@ class PackageSelectionTest extends TestCase
     #[DataProvider('dataPruneBlacklisted')]
     public function testPruneBlacklisted(array $expected, array $selected, array $config): void
     {
-        $repositorySet = new RepositorySet();
         $builder = new PackageSelection(new NullOutput(), 'build', [
             'blacklist' => $config,
         ], false);
@@ -280,7 +289,7 @@ class PackageSelectionTest extends TestCase
         $property->setValue($builder, $selected);
 
         $method = $reflection->getMethod('pruneBlacklisted');
-        $method->invokeArgs($builder, [$repositorySet, false]);
+        $method->invokeArgs($builder, [false]);
 
         self::assertEquals(array_values($expected), array_values($property->getValue($builder)));
     }


### PR DESCRIPTION
pruneBlacklisted() used RepositorySet::createPoolWithAllPackages(), which calls getPackages() on every repository — provider-based composer repositories (e.g. repo.magento.com) throw a LogicException there. Since Pool::match() only inspects the candidate package itself, an empty Pool gives identical matching behavior without loading any packages.

Fixes #798

🤖 Generated with [Claude Code](https://claude.com/claude-code)