### PR TITLE
Run tini as PID 1 in Docker image to reap zombie git processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN set -eux ; \
     openssl \
     p7zip \
     subversion \
+    tini \
     unzip \
     zip ; \
   install-php-extensions \
@@ -45,6 +46,6 @@ COPY --from=build /satis /satis/
 
 WORKDIR /build
 
-ENTRYPOINT ["/satis/bin/docker-entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/satis/bin/docker-entrypoint.sh"]
 
 CMD ["--ansi", "-vvv", "build", "/build/satis.json", "/build/output"]


### PR DESCRIPTION
The entrypoint execs into the satis PHP process, making it PID 1. Orphaned git helper processes get reparented to it and are never reaped, accumulating as zombies during builds.

This wraps the entrypoint with tini so orphaned children are reaped. Signals and exit codes are forwarded transparently, so behavior is otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)