### PR TITLE
Reuse dependency pool across links with the same target package

### DIFF
--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -779,6 +779,7 @@ class PackageSelection
     private function selectLinks(RepositorySet $repositorySet, array $links, bool $isRoot, bool $verbose): array
     {
         $depsLinks = $isRoot ? [] : $links;
+        $poolsByName = [];
 
         reset($links);
 
@@ -795,7 +796,10 @@ class PackageSelection
                     $matches = false !== $match ? [$match] : [];
                 } elseif (PlatformRepository::isPlatformPackage($name)) {
                 } else {
-                    $matches = $repositorySet->createPoolForPackage($link->getTarget())->whatProvides($name, $link->getConstraint());
+                    // the pool only depends on the target name, so reuse it across
+                    // links with different constraints
+                    $poolsByName[$name] ??= $repositorySet->createPoolForPackage($name);
+                    $matches = $poolsByName[$name]->whatProvides($name, $link->getConstraint());
                 }
 
                 if (0 === \count($matches)) {


### PR DESCRIPTION
### Problem

`PackageSelection::selectLinks()` calls `RepositorySet::createPoolForPackage()` once for **every** dependency link it processes:

```php
$matches = $repositorySet->createPoolForPackage($link->getTarget())->whatProvides($name, $link->getConstraint());
```

The pool returned by `createPoolForPackage($name)` depends only on the target package **name** (and the repository set), not on the link's version constraint — the constraint is applied afterwards by `whatProvides()`. So when several links point at the same target name with different constraints, each one rebuilds an identical pool and throws it away.

Building a pool is not cheap: it walks the package's dependency graph through `PoolBuilder`. On large configurations with `require-dependencies` enabled, the same popular names recur across a great many links, so this redundant work dominates the selection phase.

The effect is especially severe for package families that **exact-pin their siblings across many releases** — e.g. the [Filament](https://github.com/filamentphp/filament) monorepo, whose subpackages require each other with `self.version`. There the same handful of names (`filament/support`, `filament/actions`, …) appear in a huge number of links, and each triggers a fresh, expensive pool build. On one real-world mirror this made `satis build` run for hours.

### Change

Memoize the pool by target name for the duration of a `selectLinks()` pass, and filter the cached pool per link with `whatProvides()`:

```php
$poolsByName[$name] ??= $repositorySet->createPoolForPackage($name);
$matches = $poolsByName[$name]->whatProvides($name, $link->getConstraint());
```

This is behaviour-preserving: `whatProvides($name, $constraint)` still applies each link's constraint, so the set of matches for every link is identical to before — only duplicate pool construction is removed. The cache lives only within a single `selectLinks()` call, where the repository set is fixed.

### Notes

- Trade-off: pools for distinct names are now retained until the pass ends, so peak memory rises modestly in exchange for the large reduction in redundant work.
- There is a related, deeper cost *inside* a single pool build for exact-pinned monorepos (`Composer\Semver\Intervals` constraint compaction is superlinear in the number of matched versions). That lives in `composer/composer`'s `PoolBuilder` and is out of scope here; this PR addresses only the redundant repetition of pool builds at the satis level.

### Testing

`composer test` (phpunit), `composer run phpstan`, and `composer run php-cs-fixer` all pass locally on PHP 8.4.
