### PR TITLE
Match locally-resolved repositories by their package names when filtering

### DIFF
--- a/docs/using.md
+++ b/docs/using.md
@@ -88,8 +88,14 @@ Note that this will still need to pull and scan all of your VCS repositories
 because any VCS repository might contain (on any branch) one of the selected
 packages.
 
-If you want to scan only the selected package and not all VCS repositories you need
-to declare a _name_ for all your package (this only work on VCS repositories type) :
+Repositories that Satis can read without any network access — `artifact`, `path`
+and `package` — are matched on the package names they actually contain, so they
+are picked up by a partial update without any extra configuration.
+
+For remote repository types, scanning every repository is the only way to know
+what they hold. If you want to scan only the selected package and not all VCS
+repositories, you need to declare a _name_ for all your package (this only works
+on VCS repositories type) :
 
 ```json
 {

--- a/src/PackageSelection/PackageSelection.php
+++ b/src/PackageSelection/PackageSelection.php
@@ -25,8 +25,11 @@ use Composer\Package\PackageInterface;
 use Composer\Package\Version\VersionSelector;
 use Composer\PartialComposer;
 use Composer\Repository\ArrayRepository;
+use Composer\Repository\ArtifactRepository;
 use Composer\Repository\ComposerRepository;
 use Composer\Repository\ConfigurableRepositoryInterface;
+use Composer\Repository\PackageRepository;
+use Composer\Repository\PathRepository;
 use Composer\Repository\PlatformRepository;
 use Composer\Repository\RepositoryInterface;
 use Composer\Repository\RepositorySet;
@@ -967,18 +970,31 @@ class PackageSelection
         return array_filter(
             $repositories,
             static function ($repository) use ($packages) {
-                if (!$repository instanceof ConfigurableRepositoryInterface) {
-                    return false;
+                if ($repository instanceof ConfigurableRepositoryInterface) {
+                    $config = $repository->getRepoConfig();
+
+                    // We need name to be set on repo config as it would otherwise be too slow on remote repos (VCS, ..)
+                    if (isset($config['name']) && in_array($config['name'], $packages, true)) {
+                        return true;
+                    }
                 }
 
-                $config = $repository->getRepoConfig();
-
-                // We need name to be set on repo config as it would otherwise be too slow on remote repos (VCS, ..)
-                if (!isset($config['name']) || !in_array($config['name'], $packages, true)) {
-                    return false;
+                // "artifact", "path" and "package" repositories resolve their whole
+                // package list from the local filesystem or from the Satis config
+                // itself, so matching the names they really provide costs no network
+                // round trip and needs no "name" in the repository config.
+                if ($repository instanceof ArtifactRepository
+                    || $repository instanceof PathRepository
+                    || $repository instanceof PackageRepository
+                ) {
+                    foreach ($repository->getPackages() as $package) {
+                        if (in_array($package->getName(), $packages, true)) {
+                            return true;
+                        }
+                    }
                 }
 
-                return true;
+                return false;
             }
         );
     }

--- a/tests/PackageSelection/PackageSelectionTest.php
+++ b/tests/PackageSelection/PackageSelectionTest.php
@@ -25,6 +25,7 @@ use Composer\Repository\PackageRepository;
 use Composer\Repository\RepositorySet;
 use Composer\Semver\Constraint\Constraint;
 use Composer\Semver\Constraint\MatchAllConstraint;
+use Composer\Util\Filesystem;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\NullOutput;
@@ -34,6 +35,16 @@ use Symfony\Component\Console\Output\NullOutput;
  */
 class PackageSelectionTest extends TestCase
 {
+    private const REPOSITORY_TYPE_ARTIFACT = 'artifact';
+    private const REPOSITORY_TYPE_PATH = 'path';
+    private const REPOSITORY_TYPE_PACKAGE = 'package';
+
+    /** Version declared by the local repository fixtures. */
+    private const FIXTURE_VERSION = '1.0.0';
+
+    /** Same version as {@see self::FIXTURE_VERSION}, as Composer normalizes it. */
+    private const FIXTURE_NORMALIZED_VERSION = '1.0.0.0';
+
     /**
      * @return array<string, mixed>
      */
@@ -1317,6 +1328,174 @@ class PackageSelectionTest extends TestCase
         foreach ($repos as $repo) {
             self::assertInstanceOf(\Composer\Repository\RepositoryInterface::class, $repo);
         }
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function dataSelectWithPackagesFilterOnLocalRepositories(): array
+    {
+        return [
+            'artifact repository' => [self::REPOSITORY_TYPE_ARTIFACT, 'vendor/artifact-package'],
+            'path repository' => [self::REPOSITORY_TYPE_PATH, 'vendor/path-package'],
+            'package repository' => [self::REPOSITORY_TYPE_PACKAGE, 'vendor/inline-package'],
+        ];
+    }
+
+    /**
+     * A partial update (`satis build satis.json web/ vendor/package`) must keep
+     * repositories Satis can read without any network access, even though those
+     * repositories carry no "name" in their config.
+     *
+     * @see https://github.com/composer/satis/issues/983
+     */
+    #[DataProvider('dataSelectWithPackagesFilterOnLocalRepositories')]
+    public function testSelectWithPackagesFilterKeepsLocalRepositories(string $repositoryType, string $packageName): void
+    {
+        $this->runPackagesFilterSelection(
+            fn (string $workDir): array => [$this->createLocalRepositoryConfig($repositoryType, $packageName, $workDir)],
+            [$packageName],
+            [$packageName]
+        );
+    }
+
+    /**
+     * The filter must still filter: a local repository that does not hold any of
+     * the requested packages has to be dropped like any other.
+     *
+     * @see https://github.com/composer/satis/issues/983
+     */
+    public function testSelectWithPackagesFilterDropsLocalRepositoriesWithoutTheFilteredPackage(): void
+    {
+        $wantedPackage = 'vendor/wanted-package';
+        $otherPackage = 'vendor/other-package';
+
+        $this->runPackagesFilterSelection(
+            fn (string $workDir): array => [
+                $this->createLocalRepositoryConfig(self::REPOSITORY_TYPE_ARTIFACT, $wantedPackage, $workDir),
+                $this->createLocalRepositoryConfig(self::REPOSITORY_TYPE_ARTIFACT, $otherPackage, $workDir),
+            ],
+            [$wantedPackage],
+            [$wantedPackage]
+        );
+    }
+
+    /**
+     * Regression guard for the pre-existing behaviour: a repository declaring a
+     * matching "name" in its Satis config is still selected through that name.
+     * This one already passes without the local-repository matching.
+     */
+    public function testSelectWithPackagesFilterStillMatchesTheRepositoryConfigName(): void
+    {
+        $packageName = 'vendor/named-package';
+
+        $this->runPackagesFilterSelection(
+            function (string $workDir) use ($packageName): array {
+                $repository = $this->createLocalRepositoryConfig(self::REPOSITORY_TYPE_ARTIFACT, $packageName, $workDir);
+                $repository['name'] = $packageName;
+
+                return [$repository];
+            },
+            [$packageName],
+            [$packageName]
+        );
+    }
+
+    /**
+     * Runs `select()` with a packages filter over a throwaway working directory
+     * and asserts which packages came out.
+     *
+     * @param callable(string): list<array<string, mixed>> $buildRepositories
+     * @param list<string> $packagesFilter
+     * @param list<string> $expectedPackageNames
+     */
+    private function runPackagesFilterSelection(
+        callable $buildRepositories,
+        array $packagesFilter,
+        array $expectedPackageNames,
+    ): void {
+        $filesystem = new Filesystem();
+        $workDir = sys_get_temp_dir() . '/satis-package-filter-' . uniqid('', true);
+        $filesystem->ensureDirectoryExists($workDir);
+
+        try {
+            $config = [
+                'name' => 'test/satis',
+                'homepage' => 'http://localhost',
+                'repositories' => $buildRepositories($workDir),
+                'require-all' => true,
+            ];
+
+            unset(Config::$defaultRepositories['packagist'], Config::$defaultRepositories['packagist.org']);
+
+            $composer = (new Factory())->createComposer(new NullIO(), $config, true, null, false);
+
+            $selection = new PackageSelection(new NullOutput(), $workDir . '/build', $config, false);
+            $selection->setPackagesFilter($packagesFilter);
+
+            $selected = $selection->select($composer, false);
+
+            $expected = array_map(
+                static fn (string $name): string => $name . '-' . self::FIXTURE_NORMALIZED_VERSION,
+                $expectedPackageNames
+            );
+            self::assertSame($expected, array_keys($selected));
+        } finally {
+            $filesystem->removeDirectory($workDir);
+        }
+    }
+
+    /**
+     * Builds the repository fixture on disk and returns its Satis config entry.
+     *
+     * @return array<string, mixed>
+     */
+    private function createLocalRepositoryConfig(string $repositoryType, string $packageName, string $workDir): array
+    {
+        $composerJson = json_encode(
+            ['name' => $packageName, 'version' => self::FIXTURE_VERSION],
+            \JSON_THROW_ON_ERROR
+        );
+
+        if (self::REPOSITORY_TYPE_PACKAGE === $repositoryType) {
+            return [
+                'type' => self::REPOSITORY_TYPE_PACKAGE,
+                'package' => ['name' => $packageName, 'version' => self::FIXTURE_VERSION],
+            ];
+        }
+
+        $filesystem = new Filesystem();
+        // One directory per package: an `artifact` repository is a directory, so
+        // two of them must not end up sharing one.
+        $repositoryDir = sprintf('%s/%s/%s', $workDir, $repositoryType, str_replace('/', '-', $packageName));
+        $filesystem->ensureDirectoryExists($repositoryDir);
+
+        if (self::REPOSITORY_TYPE_PATH === $repositoryType) {
+            if (false === file_put_contents($repositoryDir . '/composer.json', $composerJson)) {
+                self::fail('Could not write the path repository fixture in ' . $repositoryDir);
+            }
+
+            return ['type' => self::REPOSITORY_TYPE_PATH, 'url' => $repositoryDir];
+        }
+
+        $archivePath = sprintf(
+            '%s/%s-%s.zip',
+            $repositoryDir,
+            str_replace('/', '-', $packageName),
+            self::FIXTURE_VERSION
+        );
+        $archive = new \ZipArchive();
+        if (true !== $archive->open($archivePath, \ZipArchive::CREATE)) {
+            self::fail('Could not create the artifact repository fixture ' . $archivePath);
+        }
+
+        try {
+            $archive->addFromString('composer.json', $composerJson);
+        } finally {
+            $archive->close();
+        }
+
+        return ['type' => self::REPOSITORY_TYPE_ARTIFACT, 'url' => $repositoryDir];
     }
 }
 


### PR DESCRIPTION
Fixes #983

## Problem

A partial update — `php bin/satis build satis.json web/ this/package` — aborts as
soon as the package lives in an `artifact` repository:

```
In PackageSelection.php line 224:

  Could not find any repositories config with "name" matching your package(s) filter: this/package
```

`PackageSelection::filterPackages()` kept only the repositories whose Satis
config declared a matching `name`. That `name` exists for a good reason, spelled
out in the code comment right above the check: enumerating a remote repository
just to learn what it contains would be too slow. But `artifact`, `path` and
`package` repositories are read straight from the local filesystem or from
`satis.json` itself, so listing what they hold costs no network round trip — and
requiring a `name` on them dropped every repository and aborted the build.

The docs already describe the `name` mechanism as a VCS-repository thing
("this only work on VCS repositories type"), so the requirement leaking onto
local repository types looks unintended rather than by design.

All three local repository types are affected identically — this is one root
cause, not three:

```
artifact  => InvalidArgumentException: Could not find any repositories config with "name" matching your package(s) filter: vendor/artifact-package
path      => InvalidArgumentException: Could not find any repositories config with "name" matching your package(s) filter: vendor/path-package
package   => InvalidArgumentException: Could not find any repositories config with "name" matching your package(s) filter: vendor/inline-package
```

## Change

`filterPackages()` now keeps the existing repo-config `name` check first and
unchanged, then falls back to matching the package names an `artifact`, `path`
or `package` repository actually provides. The remote path is untouched, so the
change is purely additive: every repository selected before is still selected.

Trade-off worth naming: when the filter does *not* match, these repositories are
now initialized (reading the zips / scanning the directory) instead of being
dropped unread. That is local file I/O only, it is memoized by `ArrayRepository`,
and the build performs it anyway for repositories that are kept.

`docs/using.md` is updated in the same PR, since it is where the `name`
requirement is documented.

## Test verification (RED → GREEN)

RED — the new tests on unmodified `main`, production code untouched
(`grep -c ArtifactRepository src/PackageSelection/PackageSelection.php` → `0`):

```
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

EEEE.                                                               5 / 5 (100%)

Package Selection (Composer\Satis\PackageSelection\PackageSelection)
 ✘ Select with packages filter keeps local repositories with data set "artifact repository"
   │ InvalidArgumentException: Could not find any repositories config with "name" matching your package(s) filter: vendor/artifact-package
   │ src/PackageSelection/PackageSelection.php:225
 ✘ Select with packages filter keeps local repositories with data set "path repository"
   │ InvalidArgumentException: Could not find any repositories config with "name" matching your package(s) filter: vendor/path-package
 ✘ Select with packages filter keeps local repositories with data set "package repository"
   │ InvalidArgumentException: Could not find any repositories config with "name" matching your package(s) filter: vendor/inline-package
 ✘ Select with packages filter drops local repositories without the filtered package
   │ InvalidArgumentException: Could not find any repositories config with "name" matching your package(s) filter: vendor/wanted-package
 ✔ Select with packages filter still matches the repository config name

ERRORS!
Tests: 5, Assertions: 1, Errors: 4.
```

GREEN — same tests, same assertions, with the fix:

```
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

.....                                                               5 / 5 (100%)

Package Selection (Composer\Satis\PackageSelection\PackageSelection)
 ✔ Select with packages filter keeps local repositories with data set "artifact repository"
 ✔ Select with packages filter keeps local repositories with data set "path repository"
 ✔ Select with packages filter keeps local repositories with data set "package repository"
 ✔ Select with packages filter drops local repositories without the filtered package
 ✔ Select with packages filter still matches the repository config name

OK (5 tests, 5 assertions)
```

Note on the 5th test: `testSelectWithPackagesFilterStillMatchesTheRepositoryConfigName`
passes both before and after on purpose. It is a regression guard for the
existing VCS-style `name` matching, not evidence for the fix.

## Full suite

`composer run test`, before and after, on every matrix cell of `ci.yaml`
(PHP 8.4 / 8.5 × `prefer-lowest` / `prefer-stable`):

| | Tests | Assertions | Incomplete | Failures |
|---|---|---|---|---|
| `main` | 172 | 317 | 5 | 0 |
| this branch | 177 | 322 | 5 | 0 |

`php-cs-fixer`, `phpstan` (level 8 + strict + deprecation rules), `eslint`,
`prettier` and `yamllint` were also run before and after: green in both cases,
with no new entry in `phpstan-baseline.neon`.
