### PR TITLE
Add a remove command to drop a repository from the Satis config

### DIFF
--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -69,6 +69,7 @@ class Application extends ComposerApplication
             new Command\AddCommand(),
             new Command\BuildCommand(),
             new Command\PurgeCommand(),
+            new Command\RemoveCommand(),
         ]);
 
         return $commands;

--- a/src/Console/Command/RemoveCommand.php
+++ b/src/Console/Command/RemoveCommand.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of composer/satis.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Composer\Satis\Console\Command;
+
+use Composer\Command\BaseCommand;
+use Composer\Json\JsonFile;
+use Symfony\Component\Console\Helper\FormatterHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RemoveCommand extends BaseCommand
+{
+    protected function configure(): void
+    {
+        $this->getName() ?? $this->setName('remove');
+        $this
+            ->setDescription('Remove repository URL from satis JSON file')
+            ->setDefinition([
+                new InputArgument('url', InputArgument::REQUIRED, 'VCS repository URL'),
+                new InputArgument('file', InputArgument::OPTIONAL, 'JSON file to use', './satis.json'),
+            ])
+            ->setHelp(
+                <<<'EOT'
+                The <info>remove</info> command removes the given repository URL from the json
+                file (satis.json is used by default). You will need to run <comment>build</comment> command
+                to regenerate your repository without that repository, and <comment>purge</comment> to
+                drop the archives it left behind.
+                EOT
+            );
+    }
+
+    /**
+     * Exit codes mirror AddCommand: 2 for a remote config file, 1 for a config
+     * file that does not exist, 0 on success. Where AddCommand returns 4 for a
+     * URL that is already in the config, this returns 4 for a URL that is not.
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var FormatterHelper $formatter */
+        $formatter = $this->getHelper('formatter');
+
+        $configFile = $input->getArgument('file');
+        $repositoryUrl = $input->getArgument('url');
+
+        if (1 === preg_match('{^https?://}i', $configFile)) {
+            $output->writeln('<error>Unable to write to remote file ' . $configFile . '</error>');
+
+            return 2;
+        }
+
+        $file = new JsonFile($configFile);
+        if (!$file->exists()) {
+            $output->writeln('<error>File not found: ' . $configFile . '</error>');
+
+            return 1;
+        }
+
+        $config = $file->read();
+        $repositories = [];
+        if (isset($config['repositories']) && is_array($config['repositories'])) {
+            $repositories = $config['repositories'];
+        }
+
+        $remaining = array_values(array_filter(
+            $repositories,
+            static fn ($repository): bool => !isset($repository['url']) || $repository['url'] !== $repositoryUrl
+        ));
+
+        if (count($remaining) === count($repositories)) {
+            $output->writeln('<error>Repository url not found in the file</error>');
+
+            return 4;
+        }
+
+        $config['repositories'] = $remaining;
+
+        $file->write($config);
+
+        $output->writeln([
+            '',
+            $formatter->formatBlock('Your configuration file successfully updated! It\'s time to rebuild your repository', 'bg=blue;fg=white', true),
+            '',
+        ]);
+
+        return 0;
+    }
+}

--- a/src/Plugin/CommandProvider.php
+++ b/src/Plugin/CommandProvider.php
@@ -18,6 +18,7 @@ use Composer\Satis\Console\Command\AddCommand;
 use Composer\Satis\Console\Command\BuildCommand;
 use Composer\Satis\Console\Command\InitCommand;
 use Composer\Satis\Console\Command\PurgeCommand;
+use Composer\Satis\Console\Command\RemoveCommand;
 
 /**
  * Register commands for the Composer CLI
@@ -31,6 +32,7 @@ class CommandProvider implements CommandProviderCapability
             new BuildCommand('satis:build'),
             new InitCommand('satis:init'),
             new PurgeCommand('satis:purge'),
+            new RemoveCommand('satis:remove'),
         ];
     }
 }

--- a/tests/Console/Command/RemoveCommandTest.php
+++ b/tests/Console/Command/RemoveCommandTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of composer/satis.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Composer\Satis\Console\Command;
+
+use Composer\Console\Application;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[TestDox('RemoveCommand')]
+class RemoveCommandTest extends TestCase
+{
+    private const REPOSITORY_URL = 'https://github.com/foo/bar.git';
+    private const OTHER_REPOSITORY_URL = 'https://github.com/existing/repo.git';
+
+    private string $configPath;
+
+    protected function setUp(): void
+    {
+        vfsStream::setup('satis');
+        $this->configPath = vfsStream::url('satis/satis.json');
+    }
+
+    private function createTester(): CommandTester
+    {
+        $app = new Application();
+        $app->addCommand(new RemoveCommand());
+
+        return new CommandTester($app->find('remove'));
+    }
+
+    /** @param array<string, mixed> $config */
+    private function writeConfig(array $config): void
+    {
+        file_put_contents(
+            $this->configPath,
+            json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+    }
+
+    /** @return array<string, mixed> */
+    private function readConfig(): array
+    {
+        $contents = file_get_contents($this->configPath);
+        self::assertIsString($contents);
+
+        return json_decode($contents, true);
+    }
+
+    #[TestDox('Rejects an HTTP URL as the config file path')]
+    public function testRejectsHttpConfigFile(): void
+    {
+        $tester = $this->createTester();
+        $tester->execute(['url' => self::REPOSITORY_URL, 'file' => 'http://example.com/satis.json']);
+
+        self::assertSame(2, $tester->getStatusCode());
+        self::assertStringContainsString('Unable to write to remote file', $tester->getDisplay());
+    }
+
+    #[TestDox('Rejects an HTTPS URL as the config file path')]
+    public function testRejectsHttpsConfigFile(): void
+    {
+        $tester = $this->createTester();
+        $tester->execute(['url' => self::REPOSITORY_URL, 'file' => 'https://example.com/satis.json']);
+
+        self::assertSame(2, $tester->getStatusCode());
+        self::assertStringContainsString('Unable to write to remote file', $tester->getDisplay());
+    }
+
+    #[TestDox('Rejects a config file that does not exist')]
+    public function testRejectsNonExistentFile(): void
+    {
+        $tester = $this->createTester();
+        $tester->execute(['url' => self::REPOSITORY_URL, 'file' => vfsStream::url('satis/nonexistent.json')]);
+
+        self::assertSame(1, $tester->getStatusCode());
+        self::assertStringContainsString('File not found', $tester->getDisplay());
+    }
+
+    #[TestDox('Rejects a repository URL that is not in the config')]
+    public function testRejectsUnknownUrl(): void
+    {
+        $this->writeConfig([
+            'name' => 'test/repo',
+            'repositories' => [
+                ['type' => 'vcs', 'url' => self::OTHER_REPOSITORY_URL],
+            ],
+        ]);
+        $tester = $this->createTester();
+        $tester->execute(['url' => self::REPOSITORY_URL, 'file' => $this->configPath]);
+
+        self::assertSame(4, $tester->getStatusCode());
+        self::assertStringContainsString('Repository url not found in the file', $tester->getDisplay());
+
+        $config = $this->readConfig();
+        self::assertCount(1, $config['repositories']);
+    }
+
+    #[TestDox('Rejects a repository URL when the config has no repositories at all')]
+    public function testRejectsUnknownUrlWithoutRepositoriesKey(): void
+    {
+        $this->writeConfig(['name' => 'test/repo']);
+        $tester = $this->createTester();
+        $tester->execute(['url' => self::REPOSITORY_URL, 'file' => $this->configPath]);
+
+        self::assertSame(4, $tester->getStatusCode());
+        self::assertStringContainsString('Repository url not found in the file', $tester->getDisplay());
+    }
+
+    #[TestDox('Rejects a repository URL when the repositories value is not an array')]
+    public function testRejectsUnknownUrlWithNonArrayRepositories(): void
+    {
+        $this->writeConfig(['name' => 'test/repo', 'repositories' => 'invalid']);
+        $tester = $this->createTester();
+        $tester->execute(['url' => self::REPOSITORY_URL, 'file' => $this->configPath]);
+
+        self::assertSame(4, $tester->getStatusCode());
+        self::assertStringContainsString('Repository url not found in the file', $tester->getDisplay());
+    }
+
+    #[TestDox('Removes the only repository from the config')]
+    public function testRemoveOnlyRepository(): void
+    {
+        $this->writeConfig([
+            'name' => 'test/repo',
+            'repositories' => [
+                ['type' => 'vcs', 'url' => self::REPOSITORY_URL],
+            ],
+        ]);
+        $tester = $this->createTester();
+        $tester->execute(['url' => self::REPOSITORY_URL, 'file' => $this->configPath]);
+
+        self::assertSame(0, $tester->getStatusCode());
+        self::assertStringContainsString('successfully updated', $tester->getDisplay());
+
+        $config = $this->readConfig();
+        self::assertSame([], $config['repositories']);
+    }
+
+    #[TestDox('Preserves the other repositories and reindexes the list')]
+    public function testRemovePreservesOtherRepositories(): void
+    {
+        $this->writeConfig([
+            'name' => 'test/repo',
+            'repositories' => [
+                ['type' => 'vcs', 'url' => self::REPOSITORY_URL],
+                ['type' => 'vcs', 'url' => self::OTHER_REPOSITORY_URL],
+            ],
+        ]);
+        $tester = $this->createTester();
+        $tester->execute(['url' => self::REPOSITORY_URL, 'file' => $this->configPath]);
+
+        self::assertSame(0, $tester->getStatusCode());
+
+        $config = $this->readConfig();
+        // Reindexed, so the remaining repository is at offset 0 and the list is
+        // still encoded as a JSON array rather than an object.
+        self::assertSame([0], array_keys($config['repositories']));
+        self::assertSame(self::OTHER_REPOSITORY_URL, $config['repositories'][0]['url']);
+    }
+
+    #[TestDox('Removes every entry sharing the same URL')]
+    public function testRemoveEveryEntryWithTheSameUrl(): void
+    {
+        $this->writeConfig([
+            'name' => 'test/repo',
+            'repositories' => [
+                ['type' => 'vcs', 'url' => self::REPOSITORY_URL, 'name' => 'foo/bar'],
+                ['type' => 'vcs', 'url' => self::REPOSITORY_URL],
+                ['type' => 'vcs', 'url' => self::OTHER_REPOSITORY_URL],
+            ],
+        ]);
+        $tester = $this->createTester();
+        $tester->execute(['url' => self::REPOSITORY_URL, 'file' => $this->configPath]);
+
+        self::assertSame(0, $tester->getStatusCode());
+
+        $config = $this->readConfig();
+        self::assertCount(1, $config['repositories']);
+        self::assertSame(self::OTHER_REPOSITORY_URL, $config['repositories'][0]['url']);
+    }
+
+    #[TestDox('Leaves the rest of the configuration untouched')]
+    public function testRemoveKeepsOtherConfigKeys(): void
+    {
+        $this->writeConfig([
+            'name' => 'test/repo',
+            'homepage' => 'https://packages.example.org',
+            'require-all' => true,
+            'repositories' => [
+                ['type' => 'vcs', 'url' => self::REPOSITORY_URL],
+            ],
+        ]);
+        $tester = $this->createTester();
+        $tester->execute(['url' => self::REPOSITORY_URL, 'file' => $this->configPath]);
+
+        self::assertSame(0, $tester->getStatusCode());
+
+        $config = $this->readConfig();
+        self::assertSame('test/repo', $config['name']);
+        self::assertSame('https://packages.example.org', $config['homepage']);
+        self::assertTrue($config['require-all']);
+    }
+
+    #[TestDox('Keeps repository entries that have no url')]
+    public function testRemoveKeepsRepositoriesWithoutUrl(): void
+    {
+        $this->writeConfig([
+            'name' => 'test/repo',
+            'repositories' => [
+                ['type' => 'package', 'package' => ['name' => 'foo/bar', 'version' => '1.0.0']],
+                ['type' => 'vcs', 'url' => self::REPOSITORY_URL],
+            ],
+        ]);
+        $tester = $this->createTester();
+        $tester->execute(['url' => self::REPOSITORY_URL, 'file' => $this->configPath]);
+
+        self::assertSame(0, $tester->getStatusCode());
+
+        $config = $this->readConfig();
+        self::assertCount(1, $config['repositories']);
+        self::assertSame('package', $config['repositories'][0]['type']);
+    }
+}

--- a/tests/Plugin/CommandProviderTest.php
+++ b/tests/Plugin/CommandProviderTest.php
@@ -18,6 +18,7 @@ use Composer\Satis\Console\Command\AddCommand;
 use Composer\Satis\Console\Command\BuildCommand;
 use Composer\Satis\Console\Command\InitCommand;
 use Composer\Satis\Console\Command\PurgeCommand;
+use Composer\Satis\Console\Command\RemoveCommand;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
@@ -59,6 +60,7 @@ class CommandProviderTest extends TestCase
             ['satis:build', BuildCommand::class],
             ['satis:init', InitCommand::class],
             ['satis:purge', PurgeCommand::class],
+            ['satis:remove', RemoveCommand::class],
         ];
     }
 }


### PR DESCRIPTION
Fixes #1064

## Summary

`add` puts a repository URL into `satis.json`, but nothing takes one back out —
the only way to drop a repository today is to hand-edit the JSON. This adds the
mirror image of `AddCommand`:

    php bin/satis remove git@example.com:user/project.git
    composer satis:remove git@example.com:user/project.git

Both invocation forms from the issue work: the command is registered in
`Console\Application::getDefaultCommands()` for the standalone binary and in
`Plugin\CommandProvider` as `satis:remove` for the Composer CLI.

Scope follows the reading in the issue thread — the opposite of `AddCommand`,
i.e. it removes a repository entry from the Satis config. It does not touch
`require`, the built repository, or the archives; `build` and `purge` already
own those, and `add` does not touch them either.

## Behaviour

It reuses `AddCommand`'s argument shape and exit codes, so the two commands stay
symmetric:

| Situation | `add` | `remove` |
|---|---|---|
| config path is an http(s) URL | `2` | `2` |
| config file does not exist | `1` | `1` |
| URL already in / not in the config | `4` (already there) | `4` (not there) |
| success | `0` | `0` |

Details worth calling out:

- Every entry sharing the URL is removed, and the list is reindexed with
  `array_values()` so `repositories` stays a JSON array rather than turning into
  an object with numeric string keys.
- Entries without a `url` key (a `package` repository, for instance) are never
  removed.
- Removing needs no network access — unlike adding, there is no repository to
  validate — so the command is fully offline and unit-testable.

## Test verification (RED → GREEN)

RED — the new `RemoveCommandTest` plus the updated `CommandProviderTest`
expectation, applied to unmodified `main` with no production change
(`src/Console/Command/` contains only Add/Build/Init/Purge):

```
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

CommandProvider
 ✔ Implements the CommandProviderCapability interface
 ✘ Returns the expected commands in order
   │ Failed asserting that actual size 4 matches expected size 5.
   │ tests/Plugin/CommandProviderTest.php:45

RemoveCommand
 ✘ Rejects an HTTP URL as the config file path
   │ Error: Class "Composer\Satis\Console\Command\RemoveCommand" not found
 ✘ Rejects a repository URL that is not in the config
   │ Error: Class "Composer\Satis\Console\Command\RemoveCommand" not found
 ✘ Removes the only repository from the config
   │ Error: Class "Composer\Satis\Console\Command\RemoveCommand" not found
 ... (11 errors in total)

ERRORS!
Tests: 13, Assertions: 2, Errors: 11, Failures: 1.
```

GREEN — same tests, with the command:

```
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

CommandProvider
 ✔ Implements the CommandProviderCapability interface
 ✔ Returns the expected commands in order

RemoveCommand
 ✔ Rejects an HTTP URL as the config file path
 ✔ Rejects an HTTPS URL as the config file path
 ✔ Rejects a config file that does not exist
 ✔ Rejects a repository URL that is not in the config
 ✔ Rejects a repository URL when the config has no repositories at all
 ✔ Rejects a repository URL when the repositories value is not an array
 ✔ Removes the only repository from the config
 ✔ Preserves the other repositories and reindexes the list
 ✔ Removes every entry sharing the same URL
 ✔ Leaves the rest of the configuration untouched
 ✔ Keeps repository entries that have no url

OK (13 tests, 47 assertions)
```

Also exercised through the real binary, on the SCP-style VCS URL form the
issue uses:

```
--- satis.json before ---
{
  "name": "demo/repo",
  "repositories": [
    {"type": "vcs", "url": "git@example.com:user/project.git"},
    {"type": "vcs", "url": "git@example.com:user/keep.git"}
  ]
}

$ php bin/satis remove git@example.com:user/project.git /tmp/satis.json

                                                                                      
  Your configuration file successfully updated! It's time to rebuild your repository  
                                                                                      

exit=0
--- satis.json after ---
{
  "name": "demo/repo",
  "repositories": [
    {
      "type": "vcs",
      "url": "git@example.com:user/keep.git"
    }
  ]
}

$ php bin/satis remove git@example.com:user/project.git /tmp/satis.json   # again
Repository url not found in the file
exit=4
```

## Full suite

`composer run test`, before and after, on every matrix cell of `ci.yaml`
(PHP 8.4 / 8.5 × `prefer-lowest` / `prefer-stable`):

| | Tests | Assertions | Incomplete | Failures |
|---|---|---|---|---|
| `main` | 172 | 317 | 5 | 0 |
| this branch | 183 | 354 | 5 | 0 |

`php-cs-fixer`, `phpstan` (level 8 + strict + deprecation rules), `eslint`,
`prettier` and `yamllint` were also run before and after: green in both cases,
with no new entry in `phpstan-baseline.neon`.

No documentation file changes, because the repo does not enumerate its CLI
commands anywhere — `add` and `init` are not mentioned in the README or under
`docs/` either. `remove` documents itself through `setHelp()`, exactly like
`add`. Happy to add a README section covering `add` and `remove` together if
you would like one.
