### PR TITLE
Register the repositories of the config only once per build

### DIFF
--- a/src/Console/Command/BuildCommand.php
+++ b/src/Console/Command/BuildCommand.php
@@ -241,6 +241,7 @@ class BuildCommand extends BaseCommand
         $loader = new RootPackageLoader($manager, $composerConfig, $parser, $guesser);
         $satisConfigAsRootPackage = $loader->load($config);
         $composer->setPackage($satisConfigAsRootPackage);
+        $this->deduplicateRepositories($manager, $output, (bool) $verbose);
 
         $packageSelection = new PackageSelection($output, $outputDir, $config, $skipErrors);
 
@@ -321,6 +322,58 @@ class BuildCommand extends BaseCommand
         if ($verbose) {
             foreach ($removedNames as $name) {
                 $output->writeln(sprintf('<info>Removed repository %s (disabled by config)</info>', $name));
+            }
+        }
+    }
+
+    /**
+     * Drop repositories that are registered more than once in the RepositoryManager.
+     *
+     * The repositories of a Satis config reach the manager up to three times: through
+     * Factory::create() in standalone mode, through the loop above, and through
+     * RootPackageLoader::load(). Each duplicate makes PackageSelection scan the very
+     * same VCS repository again - one more `git remote update`, one more
+     * `git remote show origin` and one more composer.json read per tag and branch -
+     * which multiplies build time and load on the git servers.
+     */
+    private function deduplicateRepositories(RepositoryManager $manager, OutputInterface $output, bool $verbose = false): void
+    {
+        $refl = new \ReflectionProperty($manager, 'repositories');
+        $repositories = $refl->getValue($manager);
+
+        $seen = [];
+        $removedKeys = [];
+
+        $repositories = array_values(array_filter(
+            $repositories,
+            static function ($repo) use (&$seen, &$removedKeys): bool {
+                if (!$repo instanceof ConfigurableRepositoryInterface) {
+                    return true;
+                }
+
+                $repoConfig = $repo->getRepoConfig();
+                $url = $repoConfig['url'] ?? null;
+                $key = is_string($url) && '' !== $url
+                    ? ($repoConfig['type'] ?? '') . ' ' . rtrim($url, '/')
+                    : (string) json_encode($repoConfig);
+
+                if (isset($seen[$key])) {
+                    $removedKeys[] = $key;
+
+                    return false;
+                }
+
+                $seen[$key] = true;
+
+                return true;
+            }
+        ));
+
+        $refl->setValue($manager, $repositories);
+
+        if ($verbose) {
+            foreach (array_count_values($removedKeys) as $key => $count) {
+                $output->writeln(sprintf('<info>Removed %d duplicate registration(s) of repository %s</info>', $count, $key));
             }
         }
     }

--- a/tests/Console/Command/BuildCommandTest.php
+++ b/tests/Console/Command/BuildCommandTest.php
@@ -18,9 +18,13 @@ use Composer\Console\Application;
 use Composer\Factory;
 use Composer\IO\NullIO;
 use Composer\Json\JsonValidationException;
+use Composer\Package\Loader\RootPackageLoader;
+use Composer\Package\Version\VersionGuesser;
+use Composer\Package\Version\VersionParser;
 use Composer\Repository\ConfigurableRepositoryInterface;
 use Composer\Repository\RepositoryManager;
 use Composer\Satis\Console\Application as SatisApplication;
+use Composer\Util\ProcessExecutor;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
@@ -321,6 +325,111 @@ class BuildCommandTest extends TestCase
         $this->invokeRemoveDisabledRepositories($manager, ['packagist.org'], $output, false);
 
         self::assertSame('', $output->fetch());
+    }
+
+    #[TestDox('Repositories registered several times are only kept once')]
+    public function testDeduplicateRepositoriesRemovesDuplicates(): void
+    {
+        $repoConfig = ['type' => 'composer', 'url' => 'https://example.com/repo'];
+
+        $config = [
+            'name' => 'test/satis-repo',
+            'homepage' => 'https://example.com',
+            'repositories' => [$repoConfig],
+        ];
+
+        $composer = (new Factory())->createComposer(new NullIO(), $config, true, null, false);
+        $manager = $composer->getRepositoryManager();
+
+        // the same registration Factory::create(), BuildCommand and RootPackageLoader each perform
+        $manager->addRepository($manager->createRepository($repoConfig['type'], $repoConfig));
+        $manager->addRepository($manager->createRepository($repoConfig['type'], $repoConfig));
+
+        self::assertSame(3, $this->countRepositoriesWithUrl($manager, 'https://example.com/repo'));
+
+        $output = new BufferedOutput();
+        $this->invokeDeduplicateRepositories($manager, $output, true);
+
+        self::assertSame(1, $this->countRepositoriesWithUrl($manager, 'https://example.com/repo'));
+        self::assertStringContainsString(
+            'Removed 2 duplicate registration(s) of repository composer https://example.com/repo',
+            $output->fetch()
+        );
+    }
+
+    #[TestDox('The registration sequence of the build command yields a single repository')]
+    public function testRepositoriesOfTheConfigAreRegisteredOnce(): void
+    {
+        $repoConfig = ['type' => 'composer', 'url' => 'https://example.com/repo'];
+
+        $config = [
+            'name' => 'test/satis-repo',
+            'homepage' => 'https://example.com',
+            'repositories' => [$repoConfig],
+        ];
+
+        // 1. the Composer instance built from the Satis config, as in standalone mode
+        $composer = (new Factory())->createComposer(new NullIO(), $config, true, null, false);
+        $manager = $composer->getRepositoryManager();
+
+        // 2. the repositories the build command feeds into the manager
+        $manager->addRepository($manager->createRepository($repoConfig['type'], $repoConfig));
+
+        // 3. the root package load, which adds the repositories of the config once more
+        $parser = new VersionParser();
+        $process = new ProcessExecutor(new NullIO());
+        $process->enableAsync();
+        $guesser = new VersionGuesser($composer->getConfig(), $process, $parser);
+        $loader = new RootPackageLoader($manager, $composer->getConfig(), $parser, $guesser);
+        $loader->load($config);
+
+        self::assertSame(3, $this->countRepositoriesWithUrl($manager, 'https://example.com/repo'));
+
+        $this->invokeDeduplicateRepositories($manager);
+
+        self::assertSame(1, $this->countRepositoriesWithUrl($manager, 'https://example.com/repo'));
+    }
+
+    #[TestDox('Deduplication keeps distinct repositories')]
+    public function testDeduplicateRepositoriesKeepsDistinctRepositories(): void
+    {
+        $first = ['type' => 'composer', 'url' => 'https://example.com/first'];
+        $second = ['type' => 'composer', 'url' => 'https://example.com/second'];
+
+        $config = [
+            'name' => 'test/satis-repo',
+            'homepage' => 'https://example.com',
+            'repositories' => [$first, $second],
+        ];
+
+        $composer = (new Factory())->createComposer(new NullIO(), $config, true, null, false);
+        $manager = $composer->getRepositoryManager();
+
+        $output = new BufferedOutput();
+        $this->invokeDeduplicateRepositories($manager, $output, false);
+
+        self::assertSame(1, $this->countRepositoriesWithUrl($manager, 'https://example.com/first'));
+        self::assertSame(1, $this->countRepositoriesWithUrl($manager, 'https://example.com/second'));
+        self::assertSame('', $output->fetch());
+    }
+
+    private function invokeDeduplicateRepositories(RepositoryManager $manager, ?\Symfony\Component\Console\Output\OutputInterface $output = null, bool $verbose = false): void
+    {
+        $command = new BuildCommand();
+        $method = new \ReflectionMethod($command, 'deduplicateRepositories');
+        $method->invokeArgs($command, [$manager, $output ?? new NullOutput(), $verbose]);
+    }
+
+    private function countRepositoriesWithUrl(RepositoryManager $manager, string $url): int
+    {
+        $count = 0;
+        foreach ($manager->getRepositories() as $repo) {
+            if ($repo instanceof ConfigurableRepositoryInterface && ($repo->getRepoConfig()['url'] ?? null) === $url) {
+                ++$count;
+            }
+        }
+
+        return $count;
     }
 
     /**


### PR DESCRIPTION
The repositories of a Satis config reach the `RepositoryManager` three times: through `Factory::create($io, $config)` in standalone mode (`src/Console/Application.php:82`), through the loop in `BuildCommand::execute()` (`BuildCommand.php:227`), and through `RootPackageLoader::load($config)` (`BuildCommand.php:241`). `PackageSelection` scans every duplicate on its own, so each repository is fetched and read three times per build — three `git remote update --prune origin`, three `git remote show origin` and three composer.json reads per tag and branch. On our instance (436 VCS repositories) a full build takes ~4 h instead of ~1 h.

Reproducer, empty `COMPOSER_HOME`, `satis --no-ansi -v build satis.json out`:

```json
{
    "name": "example/duplicate-scan-repro",
    "homepage": "https://example.org",
    "repositories": [
        { "type": "git", "url": "https://github.com/Seldaek/signal-handler.git" },
        { "type": "git", "url": "https://github.com/composer/spdx-licenses.git" }
    ],
    "require-all": true,
    "output-html": false
}
```

| `Reading composer.json of …`     | before | after |
| -------------------------------- | ------ | ----- |
| composer/spdx-licenses (24 refs) | 72     | 24    |
| seld/signal-handler (8 refs)     | 24     | 8     |

Resulting package set unchanged.

This PR drops the duplicates from the manager once all three registrations happened, keeping the first occurrence and comparing `ConfigurableRepositoryInterface` repositories by type and URL — same `ReflectionProperty` approach `removeDisabledRepositories()` already uses. The loop stays, plugin mode relies on it; suppressing the re-add inside `RootPackageLoader::load()` is not possible from Satis.

Tests: `BuildCommandTest` gains three cases, one of them replaying the real registration sequence (3 before, 1 after). 191 tests green, PHPStan and php-cs-fixer clean.

Present since #701 and #709 (2022-10).